### PR TITLE
bump Staffbase/github-action-jira-release-tagging

### DIFF
--- a/.github/workflows/template_jira_tagging.yml
+++ b/.github/workflows/template_jira_tagging.yml
@@ -37,7 +37,7 @@ jobs:
           TAG_MATCHER: ${{ inputs.tag-matcher }}
 
       - name: Add release notes to JIRA tickets
-        uses: Staffbase/github-action-jira-release-tagging@v1.0.0
+        uses: Staffbase/github-action-jira-release-tagging@v1.1.0
         env:
           JIRA_BASEURL: ${{ secrets.jira-url }}
           JIRA_TOKEN: ${{ secrets.jira-token }}


### PR DESCRIPTION
### Type of Change

<!-- Select the type of your PR and add the corresponding label -->

- [ ] Bugfix
- [x] Enhancement / new feature
- [ ] Refactoring
- [ ] Documentation

### Description

bump Staffbase/github-action-jira-release-tagging to use Node16 version
https://github.com/Staffbase/github-action-jira-release-tagging/releases includes this [change](https://github.com/Staffbase/github-action-jira-release-tagging/pull/46/files) 

### Why

I saw this deprecation warning in the pipeline (example https://github.com/Staffbase/frontend/actions/runs/3226467867)
> Annotate all occurring tickets since last native release tag / Annotate all occurring tickets since last release-tag
Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: Staffbase/github-action-jira-release-tagging
### Checklist

<!-- Please go through this checklist and make sure all applicable tasks have been done -->

- [ ] Add relevant labels (for example type of change or patch/minor/major)
- [ ] Make sure not to introduce some mistakes
- [ ] Update documentation
- [ ] Review the [Contributing Guideline](../blob/main/CONTRIBUTING.md) and sign CLA
- [ ] Reference relevant issue(s) and close them after merging
