### PR TITLE
Allow passing of different Dockerfile locations

### DIFF
--- a/.github/workflows/template_gitops.yml
+++ b/.github/workflows/template_gitops.yml
@@ -13,6 +13,10 @@ on:
         required: false
         type: string
         default: private/${{ github.event.repository.name }}
+      docker-file:
+        required: false
+        type: string
+        default: './Dockerfile'
       gitops-dev:
         required: false
         type: string
@@ -61,6 +65,7 @@ jobs:
             GONOSUMDB=${{ secrets.gonosumdb }}
           docker-build-target: ${{ inputs.docker-build-target }}
           docker-image: ${{ inputs.docker-image }}
+          docker-file: ${{ inputs.docker-file }}
           gitops-token: ${{ secrets.gitops-token }}
           gitops-dev: ${{ inputs.gitops-dev }}
           gitops-stage: ${{ inputs.gitops-stage }}

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ on: [ push ]
 
 jobs:
   gitops:
-    uses: Staffbase/gha-workflows/.github/workflows/template_gitops.yml@v1.10.0
+    uses: Staffbase/gha-workflows/.github/workflows/template_gitops.yml@v1.11.0
     with:
       # optional: list of build-time variables
       docker-build-args: |
@@ -83,6 +83,8 @@ jobs:
       docker-build-target: "any target"
       # optional: name of the docker image, default: private/<repository_name>
       docker-image: <your-image>
+      # optional: path to the Dockerfile, default: ./Dockerfile
+      docker-file: <path-to-Dockerfile>
       # optional: files which should be updated for dev
       gitops-dev: |-
         your files


### PR DESCRIPTION
### Type of Change

<!-- Select the type of your PR and add the corresponding label -->

- [ ] Bugfix
- [x] Enhancement / new feature
- [ ] Refactoring
- [x] Documentation

### Description

The GitOps Action actually supports passing a `docker-file` argument. However, this action doesn't support. By adding it here, it allows us to use this action even if we have a Dockerfile that isn't in the current working directory.

### Checklist

<!-- Please go through this checklist and make sure all applicable tasks have been done -->

- [x] Add relevant labels (for example type of change or patch/minor/major)
- [x] Make sure not to introduce some mistakes
- [x] Update documentation
- [x] Review the [Contributing Guideline](../blob/main/CONTRIBUTING.md) and sign CLA
- [ ] Reference relevant issue(s) and close them after merging
