### PR TITLE
Bump the used gitops action version to v5

### DIFF
--- a/.github/workflows/template_gitops.yml
+++ b/.github/workflows/template_gitops.yml
@@ -12,7 +12,7 @@ on:
       docker-image:
         required: false
         type: string
-        default: private/${{ github.event.repository.name }}
+        default: sb-images/${{ github.event.repository.name }}
       gitops-dev:
         required: false
         type: string

--- a/.github/workflows/template_gitops.yml
+++ b/.github/workflows/template_gitops.yml
@@ -49,7 +49,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: GitOps (build, push and deploy a new Docker image)
-        uses: Staffbase/gitops-github-action@v4.1
+        uses: Staffbase/gitops-github-action@v5
         with:
           docker-username: ${{ secrets.docker-username }}
           docker-password: ${{ secrets.docker-password }}


### PR DESCRIPTION
### Type of Change

<!-- Select the type of your PR and add the corresponding label -->

- [ ] Bugfix
- [x] Enhancement / new feature
- [ ] Refactoring
- [ ] Documentation

### Description

Use the new Gitops Action version with Artifactory as the new default.