### PR TITLE
Use Azure as default publisher for TechDocs

### DIFF
--- a/.github/workflows/template_techdocs.yml
+++ b/.github/workflows/template_techdocs.yml
@@ -3,6 +3,14 @@ name: TechDocs
 on:
   workflow_call:
     inputs:
+      publisher-type:
+        required: false
+        type: string
+        default: 'azureBlobStorage'
+      storage-name:
+        required: false
+        type: string
+        default: 'staffbase-backstage-techdocs'
       aws-region:
         required: false
         type: string
@@ -23,6 +31,10 @@ on:
         required: false
       aws-secret-access-key:
         required: false
+      azure-account-name:
+        required: false
+      azure-access-key:
+        required: false
 
 jobs:
   techdocs:
@@ -39,9 +51,11 @@ jobs:
         with:
           entity-kind: ${{ inputs.entity-kind }}
           entity-name: ${{ inputs.entity-name }}
-          publisher-type: 'awsS3'
-          storage-name: 'staffbase-backstage-techdocs'
+          publisher-type: ${{ inputs.publisher-type }}
+          storage-name: ${{ inputs.storage-name }}
           aws-region: ${{ inputs.aws-region }}
           aws-access-key-id: ${{ secrets.aws-access-key-id }}
           aws-secret-access-key: ${{ secrets.aws-secret-access-key }}
+          azure-account-name: ${{ secrets.azure-account-name }}
+          azure-access-key: ${{ secrets.azure-access-key }}
           additional-plugins: ${{ inputs.additional-plugins }}

--- a/README.md
+++ b/README.md
@@ -249,10 +249,10 @@ jobs:
       # optional: list of space separated additional python plugins to install
       additional-plugins: 'mkdocs-minify-plugin\>=0.3'
     secrets:
-      # optional: specifies an aws access key associated with an IAM user or role
-      aws-access-key-id: ${{ secrets.TECHDOCS_AWS_ACCESS_KEY_ID }}
-      # optional: specifies the secret key associated with the access key
-      aws-secret-access-key: ${{ secrets.TECHDOCS_AWS_SECRET_ACCESS_KEY }}
+      # optional: specifies an Azure Storage account name
+      azure-account-name: ${{ secrets.TECHDOCS_AWS_ACCESS_KEY_ID }}
+      # optional: specifies the access key associated with the storage account
+      azure-access-key: ${{ secrets.TECHDOCS_AZURE_ACCESS_KEY }}
 ```
 </details>
 


### PR DESCRIPTION
### Type of Change

<!-- Select the type of your PR and add the corresponding label -->

- [ ] Bugfix
- [x] Enhancement / new feature
- [ ] Refactoring
- [ ] Documentation

### Description

This will change the behavior of the techdocs action to publish to Azure Blob storage by default.

Configuration was enhanced to support both publish targets AWS and Azure.

### Checklist

<!-- Please go through this checklist and make sure all applicable tasks have been done -->

- [x] Add relevant labels (for example type of change or patch/minor/major)
- [ ] Make sure not to introduce some mistakes
- [x] Update documentation
- [ ] Review the [Contributing Guideline](../blob/main/CONTRIBUTING.md) and sign CLA
- [ ] Reference relevant issue(s) and close them after merging
