### PR TITLE
⬆️ set testio action version to v1.0.0 instead of main

### DIFF
--- a/.github/workflows/template_testio_trigger_test.yml
+++ b/.github/workflows/template_testio_trigger_test.yml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
       - name: Request required input and trigger test on TestIO
-        uses: Staffbase/testio-trigger-test-github-action@main
+        uses: Staffbase/testio-trigger-test-github-action@v1.0.0
         with:
           testio-slug: ${{ inputs.testio-slug }}
           testio-product-id: ${{ inputs.testio-product-id }}


### PR DESCRIPTION
### Type of Change

<!-- Select the type of your PR and add the corresponding label -->

- [ ] Bugfix
- [x] Enhancement / new feature
- [ ] Refactoring
- [ ] Documentation

### Description

During development the testio GHA was referenced from the main branch. Since we have a release now https://github.com/Staffbase/testio-trigger-test-github-action/releases/tag/v1.0.0 we should use it

### Checklist

<!-- Please go through this checklist and make sure all applicable tasks have been done -->

- [ ] Add relevant labels (for example type of change or patch/minor/major)
- [ ] Make sure not to introduce some mistakes
- [ ] Update documentation
- [ ] Review the [Contributing Guideline](../blob/main/CONTRIBUTING.md) and sign CLA
- [ ] Reference relevant issue(s) and close them after merging
