### PR TITLE
test: use main branch from testio GHA to test it in a separete repo

### DIFF
--- a/.github/workflows/template_testio_trigger_test.yml
+++ b/.github/workflows/template_testio_trigger_test.yml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
       - name: Trigger Test on TestIO
-        uses: Staffbase/testio-trigger-test-github-action@v1.0.3
+        uses: Staffbase/testio-trigger-test-github-action@main
         with:
           testio-slug: ${{ inputs.testio-slug }}
           testio-product-id: ${{ inputs.testio-product-id }}


### PR DESCRIPTION
Temporarily switch to `main` branch of https://github.com/Staffbase/testio-trigger-test-github-action in order to be able to test correct functionality.