### PR TITLE
Disable auto-merge for dependency bumps with major version 0

### DIFF
--- a/.github/workflows/template_automerge_dependabot.yml
+++ b/.github/workflows/template_automerge_dependabot.yml
@@ -37,7 +37,10 @@ jobs:
           github-token: ${{ steps.get_token.outputs.token }}
 
       - name: Enable auto-merge for Dependabot PRs
-        if: steps.metadata.outputs.update-type == 'version-update:semver-patch' || steps.metadata.outputs.update-type == 'version-update:semver-minor'
+        if: >-
+          (steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
+          steps.metadata.outputs.update-type == 'version-update:semver-minor') &&
+          !startsWith(steps.metadata.outputs.previous-version, '0.')
         run: |
           gh pr review --approve "$PR_URL"
 


### PR DESCRIPTION
### Type of Change

<!-- Select the type of your PR and add the corresponding label -->

- [x] Bugfix
- [ ] Enhancement / new feature
- [ ] Refactoring
- [ ] Documentation

### Description

<!-- Please describe your pull request -->

This PR restricts the condition for performing dependency auto-merge by excluding dependencies with major version 0.

Done to adhere to semantic versioning guidelines, which state that patch and minor bumps in dependencies with major version 0 can potentially contain breaking changes.

https://semver.org/#spec-item-4

### Checklist

<!-- Please go through this checklist and make sure all applicable tasks have been done -->

- [x] Add relevant labels (for example type of change or patch/minor/major)
- [x] Make sure not to introduce some mistakes
- [ ] Update documentation
- [x] Review the [Contributing Guideline](../blob/main/CONTRIBUTING.md) and sign CLA
- [x] Reference relevant issue(s) and close them after merging
