### PR TITLE
:memo: Disable staling for issues

### DIFF
--- a/.github/workflows/template_stale.yml
+++ b/.github/workflows/template_stale.yml
@@ -40,6 +40,7 @@ jobs:
         with:
           close-pr-message: ${{ inputs.close-pr-message }}
           days-before-pr-stale: ${{ inputs.days-before-pr-stale }}
+          days-before-issue-stale: -1
           delete-branch: ${{ inputs.delete-branch }}
           exempt-pr-labels: ${{ inputs.exempt-pr-labels }}
           stale-pr-label: ${{ inputs.stale-pr-label }}


### PR DESCRIPTION
### Type of Change

<!-- Select the type of your PR and add the corresponding label -->

- [x] Bugfix
- [ ] Enhancement / new feature
- [ ] Refactoring
- [ ] Documentation

### Description

<!-- Please describe your pull request -->

- I thought that the action is already configured so that no issues are staled. However, this is not the case, [which is why I am now actively deactivating the staling of issues](https://github.com/actions/stale?tab=readme-ov-file#days-before-stale). 
- You can still set the stale label manually and the action recognizes the issue as stale and then closes it after the seven days.

### Checklist

<!-- Please go through this checklist and make sure all applicable tasks have been done -->

- [x] Add relevant labels (for example type of change or patch/minor/major)
- [x] Make sure not to introduce some mistakes
- [ ] Update documentation
- [x] Review the [Contributing Guideline](../blob/main/CONTRIBUTING.md) and sign CLA
- [ ] Reference relevant issue(s) and close them after merging
