### PR TITLE
Fix: Update github-action-jira-release-tagging

### DIFF
--- a/.github/workflows/template_jira_tagging.yml
+++ b/.github/workflows/template_jira_tagging.yml
@@ -38,7 +38,7 @@ jobs:
           TAG_MATCHER: ${{ inputs.tag-matcher }}
 
       - name: Add release notes to JIRA tickets
-        uses: Staffbase/github-action-jira-release-tagging@v1.3.0
+        uses: Staffbase/github-action-jira-release-tagging@v1.3.1
         env:
           JIRA_BASEURL: ${{ secrets.jira-url }}
           JIRA_TOKEN: ${{ secrets.jira-token }}


### PR DESCRIPTION
Update github-action-jira-release-tagging to version 1.3.1 includes the workflow fix https://github.com/Staffbase/github-action-jira-release-tagging/pull/116

### Type of Change

<!-- Select the type of your PR and add the corresponding label -->

- [x] Bugfix
- [ ] Enhancement / new feature
- [ ] Refactoring
- [ ] Documentation

### Description

<!-- Please describe your pull request -->

### Checklist

<!-- Please go through this checklist and make sure all applicable tasks have been done -->

- [ ] Add relevant labels (for example type of change or patch/minor/major)
- [ ] Make sure not to introduce some mistakes
- [ ] Update documentation
- [ ] Review the [Contributing Guideline](../blob/main/CONTRIBUTING.md) and sign CLA
- [ ] Reference relevant issue(s) and close them after merging
