### PR TITLE
Add all options with our defaults to reusable workflow

### DIFF
--- a/.github/workflows/template_gitops.yml
+++ b/.github/workflows/template_gitops.yml
@@ -3,12 +3,20 @@ name: GitOps
 on:
   workflow_call:
     inputs:
+      docker-registry:
+        required: false
+        type: string
+        default: "staffbase.jfrog.io"
       docker-build-args:
         required: false
         type: string
       docker-build-target:
         required: false
         type: string
+      docker-build-provenance:
+        required: false
+        type: string
+        default: "false"
       docker-file:
         required: false
         type: string
@@ -30,6 +38,18 @@ on:
         required: false
         type: string
         default: ${{ github.repository_owner }}
+      gitops-repository:
+        required: false
+        type: string
+        default: "mops"
+      gitops-user:
+        required: false
+        type: string
+        default: "Staffbot"
+      gitops-email:
+        required: false
+        type: string
+        default: "staffbot@staffbase.com"
       working-directory:
         required: false
         type: string
@@ -79,6 +99,7 @@ jobs:
       - name: GitOps (build, push and deploy a new Docker image)
         uses: Staffbase/gitops-github-action@v5.4
         with:
+          docker-registry: ${{ inputs.docker-registry }}
           docker-username: ${{ secrets.docker-username }}
           docker-password: ${{ secrets.docker-password }}
           docker-build-args: |
@@ -87,8 +108,13 @@ jobs:
           docker-build-secrets: ${{ secrets.docker-build-secrets }}
           docker-build-secret-files: ${{ secrets.docker-build-secret-files }}
           docker-build-target: ${{ inputs.docker-build-target }}
+          docker-build-provenance: ${{ inputs.docker-build-provenance }}
           docker-file: ${{ inputs.docker-file }}
           docker-image: ${{ inputs.docker-image }}
+          gitops-organization: ${{ inputs.gitops-organization }}
+          gitops-repository: ${{ inputs.gitops-repository }}
+          gitops-user: ${{ inputs.gitops-user }}
+          gitops-email: ${{ inputs.gitops-email }}
           gitops-token: ${{ env.USING_APP_CREDENTIALS == 'true' && steps.get_token.outputs.token || secrets.gitops-token }}
           gitops-dev: ${{ inputs.gitops-dev }}
           gitops-stage: ${{ inputs.gitops-stage }}

--- a/README.md
+++ b/README.md
@@ -118,15 +118,27 @@ jobs:
   gitops:
     uses: Staffbase/gha-workflows/.github/workflows/template_gitops.yml@v5.1.0
     with:
+      # optional: host of the docker registry, default: "staffbase.jfrog.io"
+      docker-registry: "<your-registry>"
       # optional: list of build-time variables
       docker-build-args: |
         "any important args"
       # optional: set the target stage to build
       docker-build-target: "any target"
+      # optional: set the provenance level of the docker build, default: "false"
+      docker-build-provenance: "<your-provenance-level>"
       # optional: path to the Dockerfile, default: ./Dockerfile
       docker-file: <path-to-Dockerfile>
       # optional: name of the docker image, default: private/<repository_name>
       docker-image: <your-image>
+      # optional: organization of the gitops repository, default: github.repository_owner
+      gitops-organization: <your-organization>
+      # optional: repository where to update the files, default: mops
+      gitops-repository: "<your-repository>"
+      # optional: user which does the commit, default: "Staffbot"
+      gitops-user: "<your-user>"
+      # optional: email of the user which does the commit, default: "staffbot@staffbase.com"
+      gitops-email: "<your-email>"
       # optional: files which should be updated for dev
       gitops-dev: |-
         your files
@@ -136,8 +148,6 @@ jobs:
       # optional: files which should be updated for prod
       gitops-prod: |-
         your files
-      # optional: organization of the gitops repository, default: github.repository_owner
-      gitops-organization: <your-organization>
     secrets:
       # optional: username for the docker registry
       docker-username: ${{ <your-docker-username> }}


### PR DESCRIPTION
### Type of Change

- [ ] Bugfix
- [x] Enhancement / new feature
- [ ] Refactoring
- [ ] Documentation

### Description

I added all possible options from the `gitops-action` to the workflow with our defaults. This should be downward compatible and gives us the possibility to remove "our" defaults from the actions themselves.

### Checklist

- [x] Add relevant labels (for example type of change or patch/minor/major)
- [x] Make sure not to introduce some mistakes
- [x] Update documentation
- [x] Review the [Contributing Guideline](../blob/main/CONTRIBUTING.md) and sign CLA
- [ ] Reference relevant issue(s) and close them after merging
