### PR TITLE
Revert "🔥 Remove approving from auto-merge workflow"

### DIFF
--- a/.github/workflows/template_automerge_dependabot.yml
+++ b/.github/workflows/template_automerge_dependabot.yml
@@ -20,6 +20,7 @@ on:
 
 jobs:
   dependabot:
+
     name: auto-merge
     runs-on: ubuntu-22.04
 
@@ -45,6 +46,8 @@ jobs:
           steps.metadata.outputs.update-type == 'version-update:semver-minor') &&
           !startsWith(steps.metadata.outputs.previous-version, '0.')
         run: |
+          gh pr review --approve "$PR_URL"
+
           MERGE_OPTIONS=()
 
           case "${{ inputs.strategy }}" in


### PR DESCRIPTION
Reverts Staffbase/gha-workflows#251

Currently all PRs without force power are not merged automatically due to this change. 