### PR TITLE
CLP-0000: Add an input type to specify update types for dependabot automerge workflow

### DIFF
--- a/.github/workflows/template_automerge_dependabot.yml
+++ b/.github/workflows/template_automerge_dependabot.yml
@@ -12,6 +12,16 @@ on:
         default: "squash"
         required: false
         type: string
+      update-types:
+        description: "Types of version update to allow (possible values are: minor, major, patch)"
+        default: "patch,minor"
+        required: false
+        type: string
+      include-pre-release:
+        description: "Include pre-release updates"
+        default: false
+        required: false
+        type: boolean
     secrets:
       app_id:
         required: true
@@ -42,9 +52,24 @@ jobs:
 
       - name: Enable auto-merge for Dependabot PRs
         if: >-
-          (steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
-          steps.metadata.outputs.update-type == 'version-update:semver-minor') &&
-          !startsWith(steps.metadata.outputs.previous-version, '0.')
+          (
+            inputs.include-pre-release ||
+            !startsWith(steps.metadata.outputs.previous-version, '0.')
+          ) &&
+          (
+            (
+              contains(inputs.update-types, 'major') &&
+              steps.metadata.outputs.update-type == 'version-update:semver-major'
+            ) ||
+            (
+              contains(inputs.update-types, 'minor') &&
+              steps.metadata.outputs.update-type == 'version-update:semver-minor'
+            ) ||
+            (
+              contains(inputs.update-types, 'patch') &&
+              steps.metadata.outputs.update-type == 'version-update:semver-patch'
+            )
+          )
         run: |
           gh pr review --approve "$PR_URL"
 

--- a/README.md
+++ b/README.md
@@ -49,6 +49,10 @@ jobs:
       force: true
       # optional: choose strategy when merging (default: squash)
       strategy: rebase, merge
+      # optional: choose which types of update you want to allow (default: minor,patch)
+      update-types: major,minor,patch
+      # optional: choose if you want to allow versions with semver 0.X.X (default: false)
+      include-pre-release: true
     secrets:
       # identifier of the GitHub App for authentication
       app_id: ${{ <your-app-id> }}


### PR DESCRIPTION
### Type of Change

<!-- Select the type of your PR and add the corresponding label -->

- [ ] Bugfix
- [x] Enhancement / new feature
- [ ] Refactoring
- [ ] Documentation

### Description

This PR adds 2 inputs to the automerge dependabot workflow:
- `update-types`: Specify which kind of updates you allow to automerge. Possible values are: `minor`, `major`, `patch`. (Default value: `minor,patch`)
- `include-pre-release`: Specify if you want to allow automerge of pre-release, semver starting with `0.`. (Default value: `false`)

### Checklist

<!-- Please go through this checklist and make sure all applicable tasks have been done -->

- [x] Add relevant labels (for example type of change or patch/minor/major)
- [x] Make sure not to introduce some mistakes
- [x] Update documentation
- [x] Review the [Contributing Guideline](../blob/main/CONTRIBUTING.md) and sign CLA
- [x] Reference relevant issue(s) and close them after merging
