### PR TITLE
Use GH var for GONOSUMDB

### DIFF
--- a/.github/workflows/template_gitops.yml
+++ b/.github/workflows/template_gitops.yml
@@ -123,7 +123,7 @@ jobs:
           docker-password: ${{ secrets.docker-password }}
           docker-build-args: |
             ${{ inputs.docker-build-args }}
-            GONOSUMDB=${{ secrets.gonosumdb }}
+            GONOSUMDB=${{ vars.gonosumdb }}
           docker-build-secrets: ${{ secrets.docker-build-secrets }}
           docker-build-secret-files: ${{ secrets.docker-build-secret-files }}
           docker-build-target: ${{ inputs.docker-build-target }}


### PR DESCRIPTION
### Type of Change

CIV-740

<!-- Select the type of your PR and add the corresponding label -->

- [ ] Bugfix
- [ ] Enhancement / new feature
- [x] Refactoring
- [ ] Documentation

### Description

This pull request includes a small change to the `.github/workflows/template_gitops.yml` file. The change updates the `GONOSUMDB` configuration to use `${{ vars.gonosumdb }}` instead of `${{ secrets.gonosumdb }}` for better alignment with the variable management approach.
