### PR TITLE
BLO-4370 Allow build architecture selection

### DIFF
--- a/.github/workflows/template_gitops.yml
+++ b/.github/workflows/template_gitops.yml
@@ -73,10 +73,6 @@ on:
         required: false
         type: string
         default: "ubuntu-24.04"
-      runs-on-arm:
-        required: false
-        type: string
-        default: "ubuntu-24.04-arm"
       upwind-organization-id:
         required: false
         type: string
@@ -108,7 +104,7 @@ on:
 jobs:
   gitops:
     name: GitOps (${{ inputs.docker-build-platform }})
-    runs-on: ${{ inputs.docker-build-platform == 'linux/arm64' && inputs.runs-on-arm || inputs.runs-on }}
+    runs-on: ${{ inputs.runs-on }}
     if: github.ref == 'refs/heads/dev' || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/')
 
     env:
@@ -141,7 +137,7 @@ jobs:
           docker-build-secret-files: ${{ secrets.docker-build-secret-files }}
           docker-build-target: ${{ inputs.docker-build-target }}
           docker-build-outputs: ${{ inputs.docker-build-outputs }}
-          docker-build-platforms: ${{ matrix.platform }}
+          docker-build-platforms: ${{ inputs.docker-build-platform }}
           docker-build-provenance: ${{ inputs.docker-build-provenance }}
           docker-disable-retagging: ${{ inputs.docker-disable-retagging }}
           docker-file: ${{ inputs.docker-file }}

--- a/.github/workflows/template_gitops.yml
+++ b/.github/workflows/template_gitops.yml
@@ -17,6 +17,11 @@ on:
         required: false
         type: string
         description: "Custom output destinations for docker build (e.g., type=registry,push=true,compression=gzip,force-compression=true). Required for DHI images."
+      docker-build-platform:
+        required: false
+        type: string
+        description: "A build platform (e.g., linux/amd64, linux/arm64). If multiple platforms are specified, the action will fail as it does not support cross-compilation."
+        default: "linux/amd64"
       docker-build-provenance:
         required: false
         type: string
@@ -68,6 +73,10 @@ on:
         required: false
         type: string
         default: "ubuntu-24.04"
+      runs-on-arm:
+        required: false
+        type: string
+        default: "ubuntu-24.04-arm"
       upwind-organization-id:
         required: false
         type: string
@@ -97,9 +106,28 @@ on:
         required: false
 
 jobs:
+  check-single-platform:
+    name: Single Platform Check
+    runs-on: ubuntu-slim
+    steps:
+      - name: Check if only a single platform is built
+        id: check_single_platform
+        run: |
+          platform="${{ inputs.docker-build-platform }}"
+          platform_count=$(echo "$platform" | tr ',' '\n' | wc -l)
+          if [ "$platform_count" -gt 1 ]; then
+              echo "Multiple platforms are built: ${platform}"
+              echo "::error::This action only supports one platform and no cross compiling."
+              exit 1
+          else
+              echo "Only a single platform is built: ${platform}"
+          fi
+
+
   gitops:
-    name: GitOps
-    runs-on: ${{ inputs.runs-on }}
+    name: GitOps (${{ inputs.docker-build-platform }})
+    needs: check-single-platform
+    runs-on: ${{ inputs.docker-build-platform == 'linux/arm64' && inputs.runs-on-arm || inputs.runs-on }}
     if: github.ref == 'refs/heads/dev' || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/')
 
     env:
@@ -120,7 +148,7 @@ jobs:
 
       - name: GitOps (build, push and deploy a new Docker image)
         id: gitops
-        uses: Staffbase/gitops-github-action@v6.5
+        uses: Staffbase/gitops-github-action@v6.6
         with:
           docker-registry: ${{ inputs.docker-registry }}
           docker-username: ${{ secrets.docker-username }}
@@ -132,6 +160,7 @@ jobs:
           docker-build-secret-files: ${{ secrets.docker-build-secret-files }}
           docker-build-target: ${{ inputs.docker-build-target }}
           docker-build-outputs: ${{ inputs.docker-build-outputs }}
+          docker-build-platforms: ${{ matrix.platform }}
           docker-build-provenance: ${{ inputs.docker-build-provenance }}
           docker-disable-retagging: ${{ inputs.docker-disable-retagging }}
           docker-file: ${{ inputs.docker-file }}

--- a/.github/workflows/template_gitops.yml
+++ b/.github/workflows/template_gitops.yml
@@ -106,27 +106,8 @@ on:
         required: false
 
 jobs:
-  check-single-platform:
-    name: Single Platform Check
-    runs-on: ubuntu-slim
-    steps:
-      - name: Check if only a single platform is built
-        id: check_single_platform
-        run: |
-          platform="${{ inputs.docker-build-platform }}"
-          platform_count=$(echo "$platform" | tr ',' '\n' | wc -l)
-          if [ "$platform_count" -gt 1 ]; then
-              echo "Multiple platforms are built: ${platform}"
-              echo "::error::This action only supports one platform and no cross compiling."
-              exit 1
-          else
-              echo "Only a single platform is built: ${platform}"
-          fi
-
-
   gitops:
     name: GitOps (${{ inputs.docker-build-platform }})
-    needs: check-single-platform
     runs-on: ${{ inputs.docker-build-platform == 'linux/arm64' && inputs.runs-on-arm || inputs.runs-on }}
     if: github.ref == 'refs/heads/dev' || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/')
 

--- a/README.md
+++ b/README.md
@@ -225,6 +225,8 @@ jobs:
       docker-build-target: 'any target'
       # optional: custom output destinations for docker build (e.g., type=registry,push=true,compression=gzip,force-compression=true). Required for DHI images.
       docker-build-outputs: '<your-output-settings>'
+      # optional: set the target platforms for build (e.g., linux/arm64), default: "linux/amd64"
+      docker-build-platform: "linux/amd64"
       # optional: set the provenance level of the docker build, default: "false"
       docker-build-provenance: '<your-provenance-level>'
       # optional: should the last stage image be retagged for the release image, default: false
@@ -252,8 +254,10 @@ jobs:
       # optional: files which should be updated for prod
       gitops-prod: |-
         your files
-      # optional: defines the github runner for the gitops step
-      runs-on: ubuntu-latest
+      # optional: defines the github runner for the gitops step if building on AMD architecture, default: ubuntu-24.04
+      runs-on: ubuntu-24.04
+      # optional: defines the github runner for the gitops step if building on ARM architecture, default: ubuntu-24.04-arm
+      runs-on-arm: ubuntu-24.04-arm
       # optional: Upwind.io client ID
       upwind-client-id: ${{ vars.UPWIND_CLIENT_ID }}
       # optional: Upwind.io organization ID

--- a/README.md
+++ b/README.md
@@ -254,10 +254,8 @@ jobs:
       # optional: files which should be updated for prod
       gitops-prod: |-
         your files
-      # optional: defines the github runner for the gitops step if building on AMD architecture, default: ubuntu-24.04
-      runs-on: ubuntu-24.04
-      # optional: defines the github runner for the gitops step if building on ARM architecture, default: ubuntu-24.04-arm
-      runs-on-arm: ubuntu-24.04-arm
+      # optional: defines the github runner for the gitops step if (e.g. ubuntu-24.04-arm for arm builds), default: ubuntu-24.04
+      runs-on: ubuntu-24.04-arm
       # optional: Upwind.io client ID
       upwind-client-id: ${{ vars.UPWIND_CLIENT_ID }}
       # optional: Upwind.io organization ID

--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ jobs:
       # optional: custom output destinations for docker build (e.g., type=registry,push=true,compression=gzip,force-compression=true). Required for DHI images.
       docker-build-outputs: '<your-output-settings>'
       # optional: set the target platforms for build (e.g., linux/arm64), default: "linux/amd64"
-      docker-build-platform: "linux/amd64"
+      docker-build-platform: "linux/arm64"
       # optional: set the provenance level of the docker build, default: "false"
       docker-build-provenance: '<your-provenance-level>'
       # optional: should the last stage image be retagged for the release image, default: false


### PR DESCRIPTION
### Type of Change

<!-- Select the type of your PR and add the corresponding label -->

- [ ] Bugfix
- [x] Enhancement / new feature
- [ ] Refactoring
- [ ] Documentation

### Description

Set:
`docker-build-platform: 'linux/arm64' `

to build an arm64 based image. You can only select one platform. Multi-arch is not supported.

Since cross-compiling with qemu is very slow, the action checks whether the target architecture matches the runner's architecture. You need to decide which arch you want. No cross-compile is allowed, because it is very slow.