### PR TITLE
chore(deps): bump Staffbase/gitops-github-action from v6.6 to v7.1

### DIFF
--- a/.github/workflows/template_gitops.yml
+++ b/.github/workflows/template_gitops.yml
@@ -127,7 +127,7 @@ jobs:
 
       - name: GitOps (build, push and deploy a new Docker image)
         id: gitops
-        uses: Staffbase/gitops-github-action@500933363014dc38ab352417d07bcc6b6e2d64bc # v6.6
+        uses: Staffbase/gitops-github-action@4c47a273ab3456d6615dde95784239b5f5a1f49d # v7.1
         with:
           docker-registry: ${{ inputs.docker-registry }}
           docker-username: ${{ secrets.docker-username }}


### PR DESCRIPTION
## Summary

- Update `Staffbase/gitops-github-action` from v6.6 to v7.1 in the `template_gitops.yml` workflow
- v7 includes internal dependency bumps (docker/setup-buildx-action v3→v4, docker/login-action v3→v4, docker/build-push-action v6→v7)
- v7.1 pins all internal GitHub Actions to full commit SHAs

No changes to the action's input/output interface — fully backward compatible.

---
<sub>The changes and the PR were generated by OpenCode.</sub>