### PR TITLE
Add AGENTS.md for AI coding agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,71 @@
+# AGENTS.md
+
+## Overview
+
+Collection of reusable GitHub Actions workflows (`on: workflow_call`) consumed by other Staffbase repos. No application code, no build system, no tests -- just YAML workflow definitions.
+
+## Dev commands
+
+```bash
+# Lint all workflow YAML (the only CI check)
+yamllint .github/workflows/
+```
+
+No build, test, or typecheck steps exist.
+
+## Critical conventions
+
+### Action pinning (most common mistake)
+
+All third-party actions MUST be pinned to **full commit SHA** with a version comment:
+
+```yaml
+# Correct
+uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+# Wrong -- never use tag refs
+uses: actions/checkout@v4
+```
+
+### Template naming
+
+Reusable workflow files are prefixed `template_` (e.g., `template_gitops.yml`). Internal-only workflows (yamllint, release-drafter, CLA, versions) have no prefix.
+
+### Self-referencing
+
+Internal workflows reference this repo's own templates via `@main`, not pinned SHA:
+
+```yaml
+uses: Staffbase/gha-workflows/.github/workflows/template_yaml.yml@main
+```
+
+### GitHub App auth pattern
+
+Many templates support dual auth -- a plain `token` secret or GitHub App credentials (`app_id` + `private_key`). The pattern uses:
+
+```yaml
+env:
+  USING_APP_CREDENTIALS: ${{ secrets.app-id != '' && secrets.private-key != '' }}
+```
+
+### Runner images
+
+- `ubuntu-slim` for lightweight jobs (default)
+- `ubuntu-24.04` when specific OS tools are needed
+
+### Permissions
+
+Every workflow declares a minimal `permissions` block. Never use broad permissions.
+
+## YAML style (`.yamllint`)
+
+- 2-space indentation, `indent-sequences: true`
+- No line-length limit
+- `document-start: disable` (yq compatibility)
+- Truthy values: only `true`, `false`, `on` allowed
+
+## Releases
+
+- PR labels `patch` / `minor` / `major` control version bumps (default: `patch`)
+- On release publish, `versions.yml` auto-updates all SHA+version refs in `README.md` and opens a PR -- do not update those manually
+- Owned by `@Staffbase/workflow-enthusiasts`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,6 +64,22 @@ Every workflow declares a minimal `permissions` block. Never use broad permissio
 - `document-start: disable` (yq compatibility)
 - Truthy values: only `true`, `false`, `on` allowed
 
+## README documentation
+
+Each template has a corresponding `<details>` example block in `README.md`. When you add or modify inputs on a template:
+
+- Add the input to the `with:` block of the matching example in `README.md`.
+- Use a **non-default** value so readers can see how to override the default.
+- Prefix the line with a comment that states whether the input is optional and what the default is:
+
+```yaml
+with:
+  # optional: choose strategy when merging (default: squash)
+  strategy: rebase
+```
+
+- Do **not** manually update the SHA/version refs in the `uses:` lines -- those are managed automatically by `versions.yml`.
+
 ## Releases
 
 - PR labels `patch` / `minor` / `major` control version bumps (default: `patch`)


### PR DESCRIPTION
### Type of Change

- [x] Documentation

### Description

Adds an `AGENTS.md` file with compact, repo-specific guidance for AI coding agents (OpenCode, Copilot, Cursor, etc.) working in this repository.

The file covers the conventions most likely to be missed by an agent without prior context:

- **Action pinning** -- full SHA with version comment, never tag refs
- **Template naming** -- `template_` prefix convention
- **Self-referencing** -- `@main` for internal workflow calls
- **GitHub App auth pattern** -- the `USING_APP_CREDENTIALS` dual-auth idiom
- **YAML style** -- non-obvious `.yamllint` settings
- **Release automation** -- don't manually edit README version refs

### Checklist

- [x] Add relevant labels (for example type of change or patch/minor/major)
- [x] Make sure not to introduce some mistakes
- [x] Update documentation
- [ ] Review the [Contributing Guideline](../blob/main/CONTRIBUTING.md) and sign CLA
- [ ] Reference relevant issue(s) and close them after merging

---
<sub>The changes and the PR were generated by OpenCode.</sub>