### PR TITLE
docs: apply deny-by-default permissions to all README examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ You can find all possible template workflows in the directory `.github/workflows
 ```yml
 name: <your name>
 
+permissions: {}
+
 on: ...
 
 jobs:
@@ -35,6 +37,8 @@ If you want to enable the force merge, make sure that the app can bypass any pro
 
 ```yml
 name: Enable Dependabot Auto-Merge
+
+permissions: {}
 
 on:
   pull_request:
@@ -69,6 +73,9 @@ jobs:
 
 ```yml
 name: Autodev
+
+permissions: {}
+
 on:
   push:
     branches-ignore:
@@ -118,6 +125,9 @@ jobs:
 
 ```yml
 name: Changeset Check
+
+permissions: {}
+
 on:
   pull_request:
     types: [opened, reopened, synchronize]
@@ -141,6 +151,8 @@ jobs:
 
 ```yml
 name: Release Changesets
+
+permissions: {}
 
 on:
   push:
@@ -182,6 +194,8 @@ jobs:
 ```yml
 name: Find flaky tests
 
+permissions: {}
+
 on:
   # At 05:00 on Monday.
   schedule:
@@ -222,6 +236,9 @@ jobs:
 
 ```yml
 name: GitOps
+
+permissions: {}
+
 on: [push]
 
 jobs:
@@ -309,6 +326,9 @@ Then the jira issues will be updated with a release date and the labels will be 
 
 ```yml
 name: Annotate Jira Issues
+
+permissions: {}
+
 on:
   push:
     tags: ['**']
@@ -343,6 +363,9 @@ The action can be used to collect and push code references for LaunchDarkly feat
 
 ```yml
 name: Find LaunchDarkly flag code references
+
+permissions: {}
+
 on:
   push:
     branches:
@@ -370,6 +393,8 @@ jobs:
 
 ```yml
 name: Merge Block
+
+permissions: {}
 
 on:
   pull_request:
@@ -399,6 +424,8 @@ More information on how to configure this file can be found [here](https://githu
 
 ```yml
 name: Release Drafter
+
+permissions: {}
 
 on:
   push:
@@ -447,6 +474,8 @@ You can remove all other version resolver from your configuration.
 
 ```yml
 name: Release Version Detector
+
+permissions: {}
 
 on:
   push:
@@ -509,6 +538,8 @@ jobs:
 ```yml
 name: Stale PRs
 
+permissions: {}
+
 on:
   schedule:
     - cron: '0 0 * * 1-5'
@@ -545,6 +576,8 @@ jobs:
 ```yml
 name: TechDocs
 
+permissions: {}
+
 on:
   push:
     branches:
@@ -575,6 +608,8 @@ jobs:
 
 ```yml
 name: TechDocs
+
+permissions: {}
 
 on:
   push:
@@ -615,6 +650,8 @@ jobs:
 ```yml
 name: Terraform
 
+permissions: {}
+
 on: [pull_request]
 
 jobs:
@@ -645,6 +682,8 @@ jobs:
 
 ```yml
 name: YAMLlint
+
+permissions: {}
 
 on:
   push:

--- a/README.md
+++ b/README.md
@@ -488,13 +488,15 @@ on:
 ```yml
 name: Secret Scan
 
+permissions: {}
+
 on: [pull_request]
 
 jobs:
   trufflehog:
-    uses: Staffbase/gha-workflows/.github/workflows/template_secret_scan.yml@963c984dde02b0a8711f0d098aa9f8a7f2e50bca # v12.0.1
     permissions:
       contents: read
+    uses: Staffbase/gha-workflows/.github/workflows/template_secret_scan.yml@963c984dde02b0a8711f0d098aa9f8a7f2e50bca # v12.0.1
 ```
 
 </details>


### PR DESCRIPTION
## Summary
- Adds top-level `permissions: {}` to every template example in the README (intro template + 17 workflows)
- Per-job `permissions:` blocks were already present and are left unchanged
- Verified the pattern end-to-end in Staffbase/casper#181, Staffbase/customer-control#3940, Staffbase/plugins#1212

## Why
GitHub Actions does **not** auto-drop workflow-level permissions when you set job-level ones. Jobs without their own `permissions:` block still inherit whatever is at the workflow level — or, if nothing is set, the repo/org default `GITHUB_TOKEN` scope (often permissive `write-all`).

Setting `permissions: {}` at the workflow level is the "deny by default" belt that pairs with the per-job "grant specifically" suspenders. It protects consumers of these examples against:
- Repos with permissive default GITHUB_TOKEN scopes
- Future job additions to a workflow that forget to declare permissions

Originally triggered by the Copilot review on Staffbase/customer-control#3940, which flagged the missing top-level block.

## Test plan
- [x] Render the README on GitHub and spot-check a few collapsed examples
- [x] Confirm CI/yamllint passes (no yaml changes, docs only)