### PR TITLE
feat(automerge)!: default `force` to true and gate on CI

### DIFF
--- a/.github/workflows/template_automerge_dependabot.yml
+++ b/.github/workflows/template_automerge_dependabot.yml
@@ -5,7 +5,8 @@ on:
   workflow_call:
     inputs:
       force:
-        default: false
+        description: "When true (default), wait for all required status checks to pass, then merge with admin privileges to bypass the code-owner review. When false, use GitHub's standard auto-merge (`--auto`), which waits for all branch protection requirements including a human code-owner approval."
+        default: true
         required: false
         type: boolean
       strategy:
@@ -87,6 +88,8 @@ jobs:
           esac
 
           if [ "${{ inputs.force }}" == 'true' ]; then
+            echo "Waiting for required status checks before admin-merging..."
+            gh pr checks "$PR_URL" --watch --required --fail-fast
             MERGE_OPTIONS+=("--admin")
           else
             MERGE_OPTIONS+=("--auto")

--- a/README.md
+++ b/README.md
@@ -25,13 +25,13 @@ In this section you can find examples of how to use template workflows. For more
 ### Auto-Merge Dependabot
 
 <details>
-<summary>The action can be used to auto-merge a dependabot PR with minor and patch updates.</summary>
+<summary>The action can be used to auto-merge a dependabot PR.</summary>
 
-The action is called by creating a PR. It is necessary that the repository is enabled for auto-merge.
-Afterward the PR will be merged with the help of the merge queue if all required conditions of the repository are fulfilled.
+This workflow triggers when dependabot creates a PR. It uses the provided GitHub App (e.g. the [staffbase-actions](https://github.com/apps/staffbase-actions) app) to approve the PR and then merges it.
 
-⚠️ You can also force a merge of a PR. This means that the PR will immediately be merged.
-If you want to enable the force merge, make sure that the app can bypass any protection rules.
+By default the workflow waits for all required status checks to pass and then merges with admin privileges (`gh pr merge --admin`). This bypasses only the code-owner review requirement — CI checks still gate the merge. This default is required for repositories subject to the org-wide "Required CODEOWNERS" ruleset, because GitHub's standard auto-merge does not honor the ruleset's bypass actors and would otherwise wait indefinitely for a human code-owner approval. Make sure the app has admin permissions (or is an allowed bypass actor) on the target repository.
+
+To fall back to GitHub's standard auto-merge (`gh pr merge --auto`) — which waits for **all** branch protection requirements including a human code-owner approval — set `force: false`. This is useful for repos excluded from the CODEOWNERS rule (e.g. `backend`, `frontend`) where a human approval flow is acceptable. Note that `force: false` requires "Allow auto-merge" to be enabled in the repository settings.
 
 ```yml
 name: Enable Dependabot Auto-Merge
@@ -45,13 +45,13 @@ jobs:
     uses: Staffbase/gha-workflows/.github/workflows/template_automerge_dependabot.yml@963c984dde02b0a8711f0d098aa9f8a7f2e50bca # v12.0.1
     permissions: {}
     with:
-      # optional: ⚠️ only enable the force merge if you want to do the merge just now
-      force: true
-      # optional: choose strategy when merging (default: squash)
-      strategy: rebase, merge
-      # optional: choose which types of update you want to allow (default: minor,patch)
+      # optional: set to false to use GitHub's standard auto-merge instead of admin merge (default: true)
+      force: false
+      # optional: merge strategy (accepted values: rebase, merge, squash. default: squash)
+      strategy: squash
+      # optional: comma-separated list of updates to accept (available types: major, minor, patch. default: minor,patch)
       update-types: major,minor,patch
-      # optional: choose if you want to allow versions with semver 0.X.X (default: false)
+      # optional: allow versions with semver 0.X.X (default: false)
       include-pre-release: true
     secrets:
       # identifier of the GitHub App for authentication
@@ -59,6 +59,8 @@ jobs:
       # private key of the GitHub App
       private_key: ${{ <your-private-key> }}
 ```
+
+> ℹ️ When `force: true` (the default), the workflow waits on required status checks via `gh pr checks --watch --required --fail-fast` before performing the admin merge. If any required check fails, the job exits non-zero and the PR stays open. Checks that aren't marked "required" in branch protection / rulesets are not waited on.
 
 </details>
 


### PR DESCRIPTION
## Summary

Two changes to `template_automerge_dependabot.yml`:

1. **Flip the default of `force`** from `false` to `true`.
2. **Gate the admin merge on CI** — when `force: true`, run `gh pr checks "$PR_URL" --watch --required --fail-fast` before `gh pr merge --admin`. A failing required check keeps the PR open.

Net effect: `force: true` now means "bypass only the code-owner review, not CI", which is the semantic teams actually want.

## ✅ End-to-end validation

Staffbase/casper#180 (`Update ruff requirement from >=0.12.12 to >=0.15.9`) ran through this PR's branch and auto-merged cleanly:

- Build + unit tests passed via `needs: build` chain.
- Template approved the PR as `staffbase-actions[bot]` at `15:05:48Z`.
- Admin-merged by `staffbase-actions[bot]` at `15:05:54Z` — **6 seconds later, no human in the loop.**

No CODEOWNERS approval was needed. CI gated the merge. Exactly the behavior we want.

## Why flip the default

The org-wide "Required CODEOWNERS" ruleset (in `infrastructure/github/staffbase/organization/locals.tf`) applies to nearly every Staffbase repo. GitHub's `--auto` does not honor ruleset bypass actors at auto-merge time — verified empirically on `cc-custom-plugin-example`: every patch-update dependabot PR there required a human (`@maximizeIT`) to click Approve before `--auto` fired.

Survey of 82 non-archived consumers:

- **67 (82%)** already pass `force: true` — including the cookiecutter template that seeds new repos.
- **15 (18%)** leave `force` unset, relying on the old default. They're silently not auto-merging in most cases.
- **0** explicitly pass `force: false`.

Of the `force: true` cohort, **51 (77%)** chain the automerge job via `needs: [...]`. For them the new check-wait is a no-op — required checks are already green when automerge runs.

## Why gate on CI

Previously `force: true` meant "immediate admin merge regardless of CI" — a latent footgun for the 15 `force: true` repos that don't chain via `needs:` (mostly low-stakes config/template repos, but still). Adding the check-wait closes that gap without adding any new input or changing the calling convention.

## Breaking changes

1. Repos relying on `force: false`'s `--auto` behavior need to pin `force: false` explicitly. Candidates: repos excluded from the CODEOWNERS ruleset (`backend`, `frontend`, `experience-studio`, `website`, `bt-*`, `md-*`, `temp-*`, `coco-c3`, `staffbase-salesforce`).
2. Repos relying on `force: true` merging even with failing CI will now be blocked by failing required checks — intentional safety improvement.

## Not in scope

`infrastructure/.github/workflows/terraform.yml` hand-rolls a rebase-on-failure pattern (calls `update-branch` when merge fails due to stale branch). That stays in `infrastructure` — it's the only consumer that needs it, and keeping the complexity at the one caller is simpler than adding a template input.

## Docs improvements

Folded compatible wording fixes from the closed #345 (credit: @pofl):
- Dropped misleading "minor and patch updates" framing.
- Linked the [staffbase-actions](https://github.com/apps/staffbase-actions) app.
- Fixed broken example `strategy: rebase, merge` → `strategy: squash` (it's a single value).
- Noted that `force: false` requires "Allow auto-merge" enabled in repo settings.

## Test plan

- [x] End-to-end verified: Staffbase/casper#180 auto-merged via this branch
- [ ] Release as a major version (`v13.0.0`)
- [ ] Release notes call out both breaking changes and the `force: false` opt-out
- [ ] Verify no-op upgrade on a chained `force: true` consumer
- [ ] Verify an unchained `force: true` consumer's next dependabot PR waits on CI before merging

🤖 Generated with [Claude Code](https://claude.com/claude-code)