### PR TITLE
docs(automerge): update docs to reflect exempt bypass

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,33 +25,30 @@ In this section you can find examples of how to use template workflows. For more
 ### Auto-Merge Dependabot
 
 <details>
-<summary>The action can be used to auto-merge a dependabot PR with minor and patch updates.</summary>
+<summary>The action can be used to auto-merge a dependabot PR.</summary>
 
-The action is called by creating a PR. It is necessary that the repository is enabled for auto-merge.
-Afterward the PR will be merged with the help of the merge queue if all required conditions of the repository are fulfilled.
+This workflow triggers when dependabot creates a PR. It uses the provided GitHub App (e.g. the [staffbase-actions](https://github.com/apps/staffbase-actions) app) to approve the PR and enables auto-merge (`gh pr merge --auto`). The PR merges automatically once all required status checks pass.
 
-⚠️ You can also force a merge of a PR. This means that the PR will immediately be merged.
-If you want to enable the force merge, make sure that the app can bypass any protection rules.
+The GitHub App must be configured as an `exempt` bypass actor in the applicable ruleset. With `exempt`, the bot's approval satisfies the code-owner review requirement and the repo-level "Allow auto-merge" setting is not required.
+
+> **`force` input (default: `false`):** Setting `force: true` switches from `--auto` to `--admin`, which bypasses all branch protection rules. This is a legacy escape hatch. Most repos should **not** set it.
 
 ```yml
 name: Enable Dependabot Auto-Merge
 
 on:
   pull_request:
-    types: [opened]
 
 jobs:
   dependabot:
     uses: Staffbase/gha-workflows/.github/workflows/template_automerge_dependabot.yml@963c984dde02b0a8711f0d098aa9f8a7f2e50bca # v12.0.1
     permissions: {}
     with:
-      # optional: ⚠️ only enable the force merge if you want to do the merge just now
-      force: true
-      # optional: choose strategy when merging (default: squash)
-      strategy: rebase, merge
-      # optional: choose which types of update you want to allow (default: minor,patch)
+      # optional: merge strategy (accepted values: rebase, merge, squash. default: squash)
+      strategy: squash
+      # optional: comma-separated list of updates to accept (available types: major, minor, patch. default: minor,patch)
       update-types: major,minor,patch
-      # optional: choose if you want to allow versions with semver 0.X.X (default: false)
+      # optional: allow versions with semver 0.X.X (default: false)
       include-pre-release: true
     secrets:
       # identifier of the GitHub App for authentication


### PR DESCRIPTION
## Summary

Docs-only update to the Auto-Merge Dependabot section of the README, reflecting the org-wide switch from `bypass_mode = "always"` to `"exempt"` on the `staffbase-actions` app in the "Required CODEOWNERS" ruleset.

## What changed

- **Lead with `--auto` as the standard path**, explaining how the `exempt` bypass makes it work end-to-end without admin privileges.
- **Frame `force: true` as a legacy escape hatch**, not the recommended configuration. Advise against setting it unless the App isn't configured as an `exempt` bypass actor.
- **Remove `force: true` from the example** so new consumers don't cargo-cult the admin bypass.
- **Fix the example trigger**: drop `types: [opened]` — workflows need `synchronize` to re-fire on dependabot rebases (see [gdrive-widget#167](https://github.com/Staffbase/gdrive-widget/pull/167) for a real-world failure from a too-narrow trigger).
- **Fix example `strategy`**: `rebase, merge` → `squash` (single value, not a comma-separated list; credit @pofl from #345).
- **Clarify comments** on `strategy` and `update-types` with accepted values.
- **Link the [staffbase-actions](https://github.com/apps/staffbase-actions) app.**

## Context

The `exempt` bypass mode (introduced Sept 2025) was applied org-wide and empirically validated on 3 repos across 3 ecosystems — see [CI-1198](https://mitarbeiterapp.atlassian.net/browse/CI-1198) for the full validation log. This docs update aligns the README with the new reality so new consumers don't reach for `force: true` when they don't need it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CI-1198]: https://mitarbeiterapp.atlassian.net/browse/CI-1198?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ