### PR TITLE
feat: pass through create-deployment input from gitops-github-action v7.2

### DIFF
--- a/.github/workflows/template_gitops.yml
+++ b/.github/workflows/template_gitops.yml
@@ -133,7 +133,7 @@ jobs:
 
       - name: GitOps (build, push and deploy a new Docker image)
         id: gitops
-        uses: Staffbase/gitops-github-action@0a0bb2220d45dff8943d83299ef9d89149510aa7 # feat/create-deployment
+        uses: Staffbase/gitops-github-action@2f0c03866d15503b7d1f1d4ca9929ec4bc9e7cf3 # v7.2
         with:
           docker-registry: ${{ inputs.docker-registry }}
           docker-username: ${{ secrets.docker-username }}

--- a/.github/workflows/template_gitops.yml
+++ b/.github/workflows/template_gitops.yml
@@ -80,6 +80,11 @@ on:
         required: false
         type: string
         default: "."
+      create-deployment:
+        required: false
+        type: boolean
+        default: false
+        description: "Create GitHub Deployments on the source repository and write tracking annotations to the GitOps CRs"
     # waiting for: https://github.com/github-community/community/discussions/17554
     secrets:
       docker-username:
@@ -108,6 +113,7 @@ jobs:
     if: github.ref == 'refs/heads/dev' || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/')
     permissions:
       contents: read
+      deployments: write
 
     env:
       USING_APP_CREDENTIALS: ${{ secrets.app-id != '' && secrets.private-key != '' }}
@@ -127,7 +133,7 @@ jobs:
 
       - name: GitOps (build, push and deploy a new Docker image)
         id: gitops
-        uses: Staffbase/gitops-github-action@4c47a273ab3456d6615dde95784239b5f5a1f49d # v7.1
+        uses: Staffbase/gitops-github-action@0a0bb2220d45dff8943d83299ef9d89149510aa7 # feat/create-deployment
         with:
           docker-registry: ${{ inputs.docker-registry }}
           docker-username: ${{ secrets.docker-username }}
@@ -157,3 +163,5 @@ jobs:
           upwind-client-secret: ${{ secrets.upwind-client-secret }}
           upwind-organization-id: ${{ inputs.upwind-organization-id }}
           working-directory: ${{ inputs.working-directory }}
+          create-deployment: ${{ inputs.create-deployment && 'true' || 'false' }}
+          github-token: ${{ inputs.create-deployment && github.token || '' }}

--- a/README.md
+++ b/README.md
@@ -245,6 +245,7 @@ jobs:
     uses: Staffbase/gha-workflows/.github/workflows/template_gitops.yml@963c984dde02b0a8711f0d098aa9f8a7f2e50bca # v12.0.1
     permissions:
       contents: read
+      deployments: write # only required when create-deployment is true
     with:
       # optional: host of the docker registry, default: "registry.staffbase.com"
       docker-registry: '<your-registry>'
@@ -284,6 +285,8 @@ jobs:
       # optional: files which should be updated for prod
       gitops-prod: |-
         your files
+      # optional: create GitHub Deployments on the source repository and write tracking annotations to the GitOps CRs, default: false
+      create-deployment: true
       # optional: defines the github runner for the gitops step if (e.g. ubuntu-24.04-arm for arm builds), default: ubuntu-24.04
       runs-on: ubuntu-24.04-arm
       # optional: Upwind.io client ID


### PR DESCRIPTION
### Type of Change

- [x] Enhancement / new feature

### Description

Passes through the new `create-deployment` input from `Staffbase/gitops-github-action@v7.2` to enable GitHub Deployment tracking (CI-1201).

**Changes to `template_gitops.yml`:**
- Updates `gitops-github-action` from v7.1 to v7.2
- New input: `create-deployment` (boolean, default `false`)
- Adds `deployments: write` permission to the job
- Passes `create-deployment` and `github-token` (from `github.token`) to the action

When `create-deployment` is enabled, the action creates a GitHub Deployment per target environment and writes tracking annotations to the Application CR in mops.

### Checklist

- [x] Add relevant labels (for example type of change or patch/minor/major)
- [x] Make sure not to introduce some mistakes
- [ ] Update documentation
- [ ] Review the [Contributing Guideline](../blob/main/CONTRIBUTING.md) and sign CLA
- [x] Reference relevant issue(s) and close them after merging

---
<sub>The changes and the PR were generated by Claude.</sub>