### PR TITLE
test: point gitops-github-action to fix/deactivate-stale-deployments

### DIFF
--- a/.github/workflows/template_gitops.yml
+++ b/.github/workflows/template_gitops.yml
@@ -133,7 +133,7 @@ jobs:
 
       - name: GitOps (build, push and deploy a new Docker image)
         id: gitops
-        uses: Staffbase/gitops-github-action@8d7d9dbf52989f74367fd063c39026d8d127daf1 # refactor/extract-scripts-and-tests
+        uses: Staffbase/gitops-github-action@8e6fd8d77bca482efcacc0e497e89cb1f0f2b120 # refactor/extract-scripts-and-tests
         with:
           docker-registry: ${{ inputs.docker-registry }}
           docker-username: ${{ secrets.docker-username }}

--- a/.github/workflows/template_gitops.yml
+++ b/.github/workflows/template_gitops.yml
@@ -133,7 +133,7 @@ jobs:
 
       - name: GitOps (build, push and deploy a new Docker image)
         id: gitops
-        uses: Staffbase/gitops-github-action@2f0c03866d15503b7d1f1d4ca9929ec4bc9e7cf3 # v7.2
+        uses: Staffbase/gitops-github-action@8b0f5e72688eb9309da87e8b5fc0aeb2a67e4c35 # fix/deactivate-stale-deployments
         with:
           docker-registry: ${{ inputs.docker-registry }}
           docker-username: ${{ secrets.docker-username }}

--- a/.github/workflows/template_gitops.yml
+++ b/.github/workflows/template_gitops.yml
@@ -133,7 +133,7 @@ jobs:
 
       - name: GitOps (build, push and deploy a new Docker image)
         id: gitops
-        uses: Staffbase/gitops-github-action@8b0f5e72688eb9309da87e8b5fc0aeb2a67e4c35 # fix/deactivate-stale-deployments
+        uses: Staffbase/gitops-github-action@8d7d9dbf52989f74367fd063c39026d8d127daf1 # refactor/extract-scripts-and-tests
         with:
           docker-registry: ${{ inputs.docker-registry }}
           docker-username: ${{ secrets.docker-username }}


### PR DESCRIPTION
### Type of Change

- [ ] Bugfix
- [ ] Enhancement / new feature
- [ ] Refactoring
- [ ] Documentation

### Description

Temporary PR to test Staffbase/gitops-github-action#131 which adds cleanup of stale in-progress GitHub Deployments before creating new ones.

Points `template_gitops.yml` to commit `8b0f5e7` on the `fix/deactivate-stale-deployments` branch of gitops-github-action.

**Do not merge** — revert to the released version once testing is complete.

### Checklist

- [ ] Add relevant labels (for example type of change or patch/minor/major)
- [ ] Make sure not to introduce some mistakes
- [ ] Update documentation
- [ ] Review the [Contributing Guideline](../blob/main/CONTRIBUTING.md) and sign CLA
- [ ] Reference relevant issue(s) and close them after merging

---
<sub>The changes and the PR were generated by Claude.</sub>