### PR TITLE
fix: replace ubuntu-slim with ubuntu-latest in flaky tests workflow

### DIFF
--- a/.github/workflows/template_flaky_tests.yml
+++ b/.github/workflows/template_flaky_tests.yml
@@ -32,7 +32,7 @@ on:
 jobs:
   flaky-tests:
     name: Flaky-Tests
-    runs-on: ubuntu-slim
+    runs-on: ubuntu-latest
     permissions:
       checks: read
       contents: read

--- a/.github/workflows/template_flaky_tests.yml
+++ b/.github/workflows/template_flaky_tests.yml
@@ -32,7 +32,7 @@ on:
 jobs:
   flaky-tests:
     name: Flaky-Tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       checks: read
       contents: read


### PR DESCRIPTION
## Problem

The `Find flaky tests` workflow was intermittently failing due to GitHub's hard **15-minute job timeout** enforced on `ubuntu-slim` runners. This caused 2 out of 3 attempts to be killed today ([example run](https://github.com/Staffbase/backend/actions/runs/24979101373/attempts/1)).

`ubuntu-slim` is a single-CPU containerized runner intended for short/lightweight tasks. Its 15-minute timeout is a fixed GitHub platform limit — it cannot be configured via `timeout-minutes` or any org/repo setting.

## Fix

Switch `runs-on` from `ubuntu-slim` to `ubuntu-latest`, which runs on a full VM with the standard 6-hour default timeout and is more appropriate for this workload.

## Impact

- No functional change to the workflow logic
- Slightly higher runner cost (billed minutes), but negligible for a weekly scheduled job

---
🤖 Disclosure: This PR was created with OpenCode