### PR TITLE
chore: bump backstage-techdocs-action to v0.2.4

### DIFF
--- a/.github/workflows/template_techdocs.yml
+++ b/.github/workflows/template_techdocs.yml
@@ -48,7 +48,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Build and Publish Site
-        uses: Staffbase/backstage-techdocs-action@050e94ff58e668123e9405a5443cc93f5378ae38 # v0.2.2
+        uses: Staffbase/backstage-techdocs-action@8767e3d6b429b73c3513aedaff3fb890111f358f # v0.2.4
         with:
           entity-kind: ${{ inputs.entity-kind }}
           entity-name: ${{ inputs.entity-name }}


### PR DESCRIPTION
## Summary
- Bump `Staffbase/backstage-techdocs-action` from v0.2.2 → v0.2.4 in `template_techdocs.yml`
- v0.2.4 internally upgrades `actions/setup-node` from v5 → v6 (Node.js 24), clearing the Node.js 20 deprecation warning users see when running this template

## Test plan
- [x] Trigger TechDocs template from a consumer repo and confirm no Node.js 20 deprecation warning (verified in Staffbase/open-source-policy#47, run [25097377040](https://github.com/Staffbase/open-source-policy/actions/runs/25097377040))
- [x] Build/publish step still succeeds against Azure Blob Storage backend

🤖 Generated with [Claude Code](https://claude.com/claude-code)