### PR TITLE
chore: bump Staffbase/autodev-action to v2.8.0

### DIFF
--- a/.github/workflows/template_autodev.yml
+++ b/.github/workflows/template_autodev.yml
@@ -82,7 +82,7 @@ jobs:
           fetch-tags: false
 
       - name: Autodev
-        uses: Staffbase/autodev-action@5be41cfbb22ad71f567f4119f0649f1a34d8b78f # v2.7.0
+        uses: Staffbase/autodev-action@77e84c1310ba60f3b514d2196e2b724651eda562 # v2.8.0
         with:
           base: ${{ inputs.base }}
           branch: ${{ inputs.branch }}


### PR DESCRIPTION
### Type of Change

- [ ] Bugfix
- [x] Enhancement / new feature
- [ ] Refactoring
- [ ] Documentation

### Description

Bumps [Staffbase/autodev-action](https://github.com/Staffbase/autodev-action) from `v2.7.0` to [`v2.8.0`](https://github.com/Staffbase/autodev-action/releases/tag/v2.8.0) in `template_autodev.yml`. The pinned commit SHA is updated accordingly.

Highlights from the upstream release:

- `fix: use --force-with-lease to abort stale dev branch pushes` (Staffbase/autodev-action#401)
- Release-drafter and dependency maintenance updates

See the full [release notes](https://github.com/Staffbase/autodev-action/releases/tag/v2.8.0) for details.

### Checklist

- [x] Add relevant labels (for example type of change or patch/minor/major)
- [x] Make sure not to introduce some mistakes
- [ ] Update documentation
- [ ] Review the [Contributing Guideline](../blob/main/CONTRIBUTING.md) and sign CLA
- [ ] Reference relevant issue(s) and close them after merging

---
<sub>The changes and the PR were generated by Claude.</sub>