### PR TITLE
fix(ci): bump pnpm/action-setup v6.0.0 → v6.0.8 (upstream bootstrap bug fixed)

### DIFF
--- a/.github/workflows/template_changeset_release.yml
+++ b/.github/workflows/template_changeset_release.yml
@@ -49,7 +49,7 @@ jobs:
           token: ${{ steps.get_token.outputs.token }}
 
       - name: Setup PNPM
-        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
 
       - name: Setup Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0

--- a/.github/workflows/template_changeset_release.yml
+++ b/.github/workflows/template_changeset_release.yml
@@ -49,7 +49,7 @@ jobs:
           token: ${{ steps.get_token.outputs.token }}
 
       - name: Setup PNPM
-        uses: pnpm/action-setup@08c4be7e2e672a47d11bd04269e27e5f3e8529cb # v6.0.0
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
 
       - name: Setup Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0


### PR DESCRIPTION
## Problem

All \`Automatic Release\` runs in repos using \`template_changeset_release.yml\` have been failing since v13.1.0 was adopted (May 8).

Error:
\`\`\`
ERR_PNPM_BROKEN_LOCKFILE  The lockfile at "pnpm-lock.yaml" is broken: expected a single document in the stream, but found more
\`\`\`

## Root Cause

\`pnpm/action-setup@v6.0.0\` (SHA \`08c4be7e\`) introduced a new bootstrap mechanism that:
1. Bootstraps with a hardcoded pnpm version — **\`11.0.0-rc.0\`** in v6.0.0
2. When \`packageManager\` is set in \`package.json\` (e.g. \`pnpm@10.28.0\`), \`readTargetVersion()\` returns \`undefined\`, so **the \`pnpm self-update\` step is skipped**
3. The bootstrap pnpm 11-rc stays and runs \`pnpm install --frozen-lockfile\` against a lockfile generated by pnpm 10 (lockfileVersion 9.0)
4. pnpm 11-rc's YAML parser fails with the "single document" error on pnpm 10 lockfiles

This is a bug in \`pnpm/action-setup\` v6.0.0–v6.0.6, fixed upstream in [pnpm/action-setup#256](https://github.com/pnpm/action-setup/pull/256) and released as **v6.0.7** (further polished in **v6.0.8**, released 2026-05-12).

## Fix

Bump \`pnpm/action-setup\` to **v6.0.8** (commit \`0e279bb9\`), which correctly handles the \`packageManager\` field in \`package.json\` and installs the pinned version instead of staying on the bootstrap pnpm 11-rc.

This is a proper upstream fix — no workaround needed.

## Verification

- Last successful run with v12 (pnpm/action-setup@v4.2.0): May 5, 2026
- All runs since v13.1.0 (pnpm/action-setup@v6.0.0): failing with same error
- Upstream fix confirmed in [pnpm/action-setup#256](https://github.com/pnpm/action-setup/pull/256), released as v6.0.7/v6.0.8

## Follow-up

After this is merged and tagged as a new release, consumers will need their \`release.yml\` updated to reference the new tag.