### PR TITLE
fix: bump gitops-github-action to v7.5.0

### DIFF
--- a/.github/workflows/template_gitops.yml
+++ b/.github/workflows/template_gitops.yml
@@ -133,7 +133,7 @@ jobs:
 
       - name: GitOps (build, push and deploy a new Docker image)
         id: gitops
-        uses: Staffbase/gitops-github-action@b703e70ebe1ec414353c9989ff6cf7414246ca9c # v7.4
+        uses: Staffbase/gitops-github-action@a90b1cb90823b35093fce0bd84746f249fe2c860 # v7.5.0
         with:
           docker-registry: ${{ inputs.docker-registry }}
           docker-username: ${{ secrets.docker-username }}


### PR DESCRIPTION
## What

Bumps `gitops-github-action` from `v7.4` to `v7.5.0`.

## Why

v7.5.0 adds support for the `staffbase-application` Helm chart image field shape. The chart splits the image into a mapping:

```yaml
image:
  repository: registry.staffbase.com/sb-images/app
  tag: dev-abc123
```

Previously, the action wrote the full URI as a scalar to the image field, replacing the mapping and causing the chart to render `image: :`.

v7.5.0 auto-detects the field shape and routes accordingly — no changes required from callers.