### PR TITLE
feat!: migrate all templates from app_id to client_id (major)

### DIFF
--- a/.github/workflows/template_autodev.yml
+++ b/.github/workflows/template_autodev.yml
@@ -47,7 +47,7 @@ on:
     secrets:
       token:
         required: false
-      app_id:
+      client_id:
         required: false
       private_key:
         required: false
@@ -63,7 +63,7 @@ jobs:
     if: github.actor != 'dependabot[bot]' && (github.event_name == 'push' || github.event.label.name == inputs.label || github.event.action == 'closed')
 
     env:
-      USING_APP_CREDENTIALS: ${{ secrets.app_id != '' && secrets.private_key != '' }}
+      USING_APP_CREDENTIALS: ${{ secrets.client_id != '' && secrets.private_key != '' }}
 
     steps:
       - name: Get App Token
@@ -71,7 +71,7 @@ jobs:
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: get_token
         with:
-          app-id: ${{ secrets.app_id }}
+          client-id: ${{ secrets.client_id }}
           private-key: ${{ secrets.private_key }}
 
       - name: Checkout

--- a/.github/workflows/template_automerge_dependabot.yml
+++ b/.github/workflows/template_automerge_dependabot.yml
@@ -23,7 +23,8 @@ on:
         required: false
         type: boolean
     secrets:
-      app_id:
+      client_id:
+        description: "Client ID of the GitHub App."
         required: true
       private_key:
         required: true
@@ -40,7 +41,7 @@ jobs:
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: get_token
         with:
-          app-id: ${{ secrets.app_id }}
+          client-id: ${{ secrets.client_id }}
           private-key: ${{ secrets.private_key }}
 
       - name: Load dependabot metadata

--- a/.github/workflows/template_changeset_release.yml
+++ b/.github/workflows/template_changeset_release.yml
@@ -22,7 +22,7 @@ on:
         required: false
         type: string
     secrets:
-      app_id:
+      client_id:
         required: true
       private_key:
         required: true
@@ -40,7 +40,7 @@ jobs:
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: get_token
         with:
-          app-id: ${{ secrets.app_id }}
+          client-id: ${{ secrets.client_id }}
           private-key: ${{ secrets.private_key }}
 
       - name: Checkout

--- a/.github/workflows/template_gitops.yml
+++ b/.github/workflows/template_gitops.yml
@@ -99,7 +99,7 @@ on:
         required: false
       gonosumdb:
         required: false
-      app-id:
+      client-id:
         required: false
       private-key:
         required: false
@@ -116,7 +116,7 @@ jobs:
       deployments: write
 
     env:
-      USING_APP_CREDENTIALS: ${{ secrets.app-id != '' && secrets.private-key != '' }}
+      USING_APP_CREDENTIALS: ${{ secrets.client-id != '' && secrets.private-key != '' }}
 
     steps:
       - name: Checkout
@@ -127,7 +127,7 @@ jobs:
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: get_token
         with:
-          app-id: ${{ secrets.app-id }}
+          client-id: ${{ secrets.client-id }}
           private-key: ${{ secrets.private-key }}
           owner: ${{inputs.gitops-organization }}
 

--- a/.github/workflows/template_release_drafter.yml
+++ b/.github/workflows/template_release_drafter.yml
@@ -31,7 +31,7 @@ on:
     secrets:
       token:
         required: false
-      app_id:
+      client_id:
         required: false
       private_key:
         required: false
@@ -45,7 +45,7 @@ jobs:
       pull-requests: read
 
     env:
-      USING_APP_CREDENTIALS: ${{ secrets.app_id != '' && secrets.private_key != '' }}
+      USING_APP_CREDENTIALS: ${{ secrets.client_id != '' && secrets.private_key != '' }}
 
     steps:
       - name: Get App Token
@@ -53,7 +53,7 @@ jobs:
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: get_token
         with:
-          app-id: ${{ secrets.app_id }}
+          client-id: ${{ secrets.client_id }}
           private-key: ${{ secrets.private_key }}
 
       - name: Update Release

--- a/.github/workflows/template_terraform_format.yml
+++ b/.github/workflows/template_terraform_format.yml
@@ -16,7 +16,7 @@ on:
         type: string
         default: "staffbase-actions[bot]@users.noreply.github.com"
     secrets:
-      app-id:
+      client-id:
         required: true
       private-key:
         required: true
@@ -33,7 +33,7 @@ jobs:
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: get_token
         with:
-          app-id: ${{ secrets.app-id }}
+          client-id: ${{ secrets.client-id }}
           private-key: ${{ secrets.private-key }}
 
       - name: Checkout

--- a/.github/workflows/versions.yml
+++ b/.github/workflows/versions.yml
@@ -28,7 +28,7 @@ jobs:
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: get_token
         with:
-          app-id: ${{ vars.STAFFBASE_ACTIONS_APP_ID }}
+          client-id: ${{ vars.STAFFBASE_ACTIONS_CLIENT_ID }}
           private-key: ${{ secrets.STAFFBASE_ACTIONS_PRIVATE_KEY }}
 
       - name: Create Pull Request

--- a/README.md
+++ b/README.md
@@ -57,8 +57,8 @@ jobs:
       # optional: allow versions with semver 0.X.X (default: false)
       include-pre-release: true
     secrets:
-      # identifier of the GitHub App for authentication
-      app_id: ${{ <your-app-id> }}
+      # client id of the GitHub App for authentication
+      client_id: ${{ <your-client-id> }}
       # private key of the GitHub App
       private_key: ${{ <your-private-key> }}
 ```
@@ -109,8 +109,8 @@ jobs:
     secrets:
       # optional: access token to fetch the pull requests
       token: ${{ <your-token> }}
-      # optional: identifier of the GitHub App for authentication
-      app_id: ${{ <your-app-id> }}
+      # optional: client id of the GitHub App for authentication
+      client_id: ${{ <your-client-id> }}
       # optional: private key of the GitHub App
       private_key: ${{ <your-private-key> }}
 ```
@@ -175,12 +175,12 @@ jobs:
       # optional: The scope to use for Node.js packages.
       node-registry-scope: '@staffbase'
     secrets:
-      # identifier of the GitHub App for authentication
-      app-id: ${{ <your-app-id> }}
+      # client id of the GitHub App for authentication
+      client_id: ${{ <your-client-id> }}
       # private key of the GitHub App
-      private-key: ${{ <your-private-key> }}
+      private_key: ${{ <your-private-key> }}
       # needs write:packages rights
-      npm-token ${{ <your-npm-token> }}
+      npm-token: ${{ <your-npm-token> }}
 ```
 
 </details>
@@ -305,8 +305,8 @@ jobs:
       gitops-token: ${{ <your-gitops-token> }}
       # optional: gonosumdb environment variable
       gonosumdb: ${{ <your-gonosumdb> }}
-      # optional: identifier of the GitHub App for authentication
-      app-id: ${{ <your-app-id> }}
+      # optional: client id of the GitHub App for authentication
+      client-id: ${{ <your-client-id> }}
       # optional: private key of the GitHub App
       private-key: ${{ <your-private-key> }}
       # optional: Upwind client secret
@@ -455,8 +455,8 @@ jobs:
     secrets:
       # optional: access token for the release drafter
       token: ${{ <your-token> }}
-      # optional: identifier of the GitHub App for authentication
-      app_id: ${{ <your-app-id> }}
+      # optional: client id of the GitHub App for authentication
+      client_id: ${{ <your-client-id> }}
       # optional: private key of the GitHub App
       private_key: ${{ <your-private-key> }}
 ```
@@ -668,7 +668,7 @@ jobs:
       committer-email: staffbase-actions[bot]@users.noreply.github.com
     secrets:
       # GitHub App is required because GITHUB_TOKEN will not trigger new actions
-      app-id: ${{ <your-app-id> }}
+      client-id: ${{ <your-client-id> }}
       private-key: ${{ <your-private-key> }}
 ```
 


### PR DESCRIPTION
## What

Org-wide migration of the GitHub App auth secret from `app_id`/`app-id` to `client_id`/`client-id` across **all** templates. `create-github-app-token` deprecated its `app-id` input in favor of `client-id`; templates now pass the secret to `client-id`.

## Migrated

| Template | before | after |
|---|---|---|
| template_automerge_dependabot | `app_id` (required) | `client_id` (required) |
| template_autodev | `app_id` | `client_id` |
| template_changeset_release | `app_id` | `client_id` |
| template_release_drafter | `app_id` | `client_id` |
| template_terraform_format | `app-id` | `client-id` |
| template_gitops | `app-id` | `client-id` |
| versions.yml (internal) | `vars.STAFFBASE_ACTIONS_APP_ID` | `vars.STAFFBASE_ACTIONS_CLIENT_ID` |

README examples updated.

## Breaking / semver

`major` label set so release-drafter cuts **v14.0.0**. Callers pin exact tags/SHAs, so nothing breaks until a caller bumps to v14 — at which point it must rename its secret to `client_id`/`client-id` **and** pass the App's *client id* value (not the numeric app id). Callers are intentionally **not** migrated here.

## Prerequisites
- Org variable `STAFFBASE_ACTIONS_CLIENT_ID` (staffbase-actions app client id) must exist — `versions.yml` in this repo uses it immediately on merge.

## Related
- Staffbase/open-source-policy#57 (adopts the auto-merge template)
- Staffbase/infrastructure#15517 (howto doc)