### PR TITLE
Update GitHub App token action to use client-id

### DIFF
--- a/.github/workflows/template_autodev.yml
+++ b/.github/workflows/template_autodev.yml
@@ -71,7 +71,7 @@ jobs:
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: get_token
         with:
-          app-id: ${{ secrets.app_id }}
+          client-id: ${{ secrets.app_id }}
           private-key: ${{ secrets.private_key }}
 
       - name: Checkout

--- a/.github/workflows/template_automerge_dependabot.yml
+++ b/.github/workflows/template_automerge_dependabot.yml
@@ -40,7 +40,7 @@ jobs:
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: get_token
         with:
-          app-id: ${{ secrets.app_id }}
+          client-id: ${{ secrets.app_id }}
           private-key: ${{ secrets.private_key }}
 
       - name: Load dependabot metadata

--- a/.github/workflows/template_changeset_release.yml
+++ b/.github/workflows/template_changeset_release.yml
@@ -40,7 +40,7 @@ jobs:
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: get_token
         with:
-          app-id: ${{ secrets.app_id }}
+          client-id: ${{ secrets.app_id }}
           private-key: ${{ secrets.private_key }}
 
       - name: Checkout

--- a/.github/workflows/template_gitops.yml
+++ b/.github/workflows/template_gitops.yml
@@ -127,7 +127,7 @@ jobs:
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: get_token
         with:
-          app-id: ${{ secrets.app-id }}
+          client-id: ${{ secrets.app-id }}
           private-key: ${{ secrets.private-key }}
           owner: ${{inputs.gitops-organization }}
 

--- a/.github/workflows/template_release_drafter.yml
+++ b/.github/workflows/template_release_drafter.yml
@@ -53,7 +53,7 @@ jobs:
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: get_token
         with:
-          app-id: ${{ secrets.app_id }}
+          client-id: ${{ secrets.app_id }}
           private-key: ${{ secrets.private_key }}
 
       - name: Update Release

--- a/.github/workflows/template_terraform_format.yml
+++ b/.github/workflows/template_terraform_format.yml
@@ -33,7 +33,7 @@ jobs:
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: get_token
         with:
-          app-id: ${{ secrets.app-id }}
+          client-id: ${{ secrets.app-id }}
           private-key: ${{ secrets.private-key }}
 
       - name: Checkout

--- a/.github/workflows/versions.yml
+++ b/.github/workflows/versions.yml
@@ -28,7 +28,7 @@ jobs:
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: get_token
         with:
-          app-id: ${{ vars.STAFFBASE_ACTIONS_APP_ID }}
+          client-id: ${{ vars.STAFFBASE_ACTIONS_APP_ID }}
           private-key: ${{ secrets.STAFFBASE_ACTIONS_PRIVATE_KEY }}
 
       - name: Create Pull Request


### PR DESCRIPTION
### Type of Change

<!-- Select the type of your PR and add the corresponding label -->

- [ ] Bugfix
- [ ] Enhancement / new feature
- [ ] Refactoring
- [ ] Documentation

### Description

- Input 'app-id' has been deprecated use 'client-id' instead.
- See https://github.com/actions/create-github-app-token/blob/main/action.yml#L11-L14

### Checklist

<!-- Please go through this checklist and make sure all applicable tasks have been done -->

- [x] Add relevant labels (for example type of change or patch/minor/major)
- [x] Make sure not to introduce some mistakes
- [ ] Update documentation
- [x] Review the [Contributing Guideline](../blob/main/CONTRIBUTING.md) and sign CLA
- [ ] Reference relevant issue(s) and close them after merging
