### PR TITLE
chore(deps): bump Staffbase/autodev-action from v2.8.0 to v2.8.1

### DIFF
--- a/.github/workflows/template_autodev.yml
+++ b/.github/workflows/template_autodev.yml
@@ -82,7 +82,7 @@ jobs:
           fetch-tags: false
 
       - name: Autodev
-        uses: Staffbase/autodev-action@77e84c1310ba60f3b514d2196e2b724651eda562 # v2.8.0
+        uses: Staffbase/autodev-action@64d919840cdafe7acbf02f650c0ca73fd3ccc230 # v2.8.1
         with:
           base: ${{ inputs.base }}
           branch: ${{ inputs.branch }}


### PR DESCRIPTION
## Summary

- Bumps `Staffbase/autodev-action` from `v2.8.0` to `v2.8.1` in `template_autodev.yml`
- Fixes [DEVS-1317](https://mitarbeiterapp.atlassian.net/browse/DEVS-1317): concurrent AutoDev runs that lose a push race now emit a warning and stay green instead of failing the workflow

## Background

When two AutoDev runs race to push to the same branch, GitHub can reject the losing push server-side with `[remote rejected] … cannot lock ref`. The previous regex only matched `[rejected]`, not `[remote rejected]`, so `leaseRejected` was `false` and the run called `setFailed()` instead of warning. v2.8.1 extends the regex to cover GitHub's server-side rejection format.

---
<sub>The changes and the PR were generated by Claude.</sub>

[DEVS-1317]: https://mitarbeiterapp.atlassian.net/browse/DEVS-1317?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ