### PR TITLE
fix(automerge): keep check green for non-genuine dependabot PRs

### DIFF
--- a/.github/workflows/template_automerge_dependabot.yml
+++ b/.github/workflows/template_automerge_dependabot.yml
@@ -46,6 +46,10 @@ jobs:
 
       - name: Load dependabot metadata
         id: metadata
+        # Soft-fail: for non-genuine dependabot PRs (e.g. unverified/rebased commits)
+        # fetch-metadata calls setFailed. Swallow it so the check stays green;
+        # empty outputs make the merge step below a no-op.
+        continue-on-error: true
         uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
         with:
           github-token: ${{ steps.get_token.outputs.token }}


### PR DESCRIPTION
## What changed
Added `continue-on-error: true` to the `Load dependabot metadata` step in `template_automerge_dependabot.yml`.

## Why needed
The job runs whenever the PR author login is `dependabot[bot]`. If `dependabot/fetch-metadata` can't verify the commit signature (rebased or otherwise non-genuine dependabot PR), it calls `setFailed` and the whole job goes red, showing a failing check in the PR overview even though nothing needed merging. Example: [patroni-selfheal run](https://github.com/Staffbase/patroni-selfheal/actions/runs/28645514753/job/84951328936?pr=101).

## Why safe
When the step soft-fails it produces no outputs. The merge step's `if` requires `steps.metadata.outputs.update-type` to equal a real value (`version-update:semver-*`); an empty value matches nothing, so the merge step is skipped. Outputs come only from the action, so a PR can't spoof them. Genuine dependabot PRs still merge exactly as before; everything else no-ops to a green check.

## How to review
Confirm the merge step still gates on a concrete `update-type`, and that no step runs after it (it's the last step, so a skip ends the job green).