### PR TITLE
feat(stale): add opt-in stale branch cleanup job

### DIFF
--- a/.github/workflows/template_stale.yml
+++ b/.github/workflows/template_stale.yml
@@ -27,6 +27,14 @@ on:
         default: 'stale'
         required: false
         type: string
+      cleanup-stale-branches:
+        default: false
+        required: false
+        type: boolean
+      days-before-branch-stale:
+        default: 14
+        required: false
+        type: number
 
 jobs:
   stale:
@@ -48,3 +56,42 @@ jobs:
           exempt-pr-labels: ${{ inputs.exempt-pr-labels }}
           stale-pr-label: ${{ inputs.stale-pr-label }}
           stale-pr-message: ${{ inputs.stale-pr-message }}
+
+  # actions/stale (above) only deletes a branch when it closes a PR attached
+  # to it. Repos that also accumulate branches with no PR at all (e.g. pushed
+  # and abandoned) need this separate sweep.
+  delete-stale-branches:
+    name: delete stale branches
+    if: inputs.cleanup-stale-branches
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+      pull-requests: read
+
+    steps:
+      - name: Delete branches with no commits for N days
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          DAYS_BEFORE_BRANCH_STALE: ${{ inputs.days-before-branch-stale }}
+        run: |
+          default_branch=$(gh api "repos/$REPO" --jq .default_branch)
+          cutoff=$(date -u -d "$DAYS_BEFORE_BRANCH_STALE days ago" +%s)
+
+          gh api "repos/$REPO/branches" --paginate --jq '.[].name' | while read -r branch; do
+            [ "$branch" = "$default_branch" ] && continue
+
+            protected=$(gh api "repos/$REPO/branches/$branch" --jq .protected)
+            [ "$protected" = "true" ] && continue
+
+            open_prs=$(gh api "repos/$REPO/pulls?state=open&head=${REPO%%/*}:$branch" --jq 'length')
+            [ "$open_prs" != "0" ] && continue
+
+            last_commit_date=$(gh api "repos/$REPO/commits/$branch" --jq .commit.committer.date)
+            last_commit_epoch=$(date -u -d "$last_commit_date" +%s)
+
+            if [ "$last_commit_epoch" -lt "$cutoff" ]; then
+              echo "Deleting stale branch: $branch (last commit $last_commit_date)"
+              gh api -X DELETE "repos/$REPO/git/refs/heads/$branch"
+            fi
+          done

--- a/README.md
+++ b/README.md
@@ -565,6 +565,10 @@ jobs:
       stale-pr-label: staling
       # optional: comment on the staled pull request, default: This PR has been automatically marked as stale because there has been no recent activity in the last 60 days. It will be closed in 7 days if no further activity occurs such as removing the label.
       stale-pr-message: your message
+      # optional: also delete branches with no commits for days-before-branch-stale, regardless of whether they have a PR, default: false
+      cleanup-stale-branches: true
+      # optional: idle number of days before deleting a branch with no PR, default: 14
+      days-before-branch-stale: 21
 ```
 
 </details>


### PR DESCRIPTION
## What changed

Adds an opt-in `delete-stale-branches` job to `template_stale.yml`, gated by a new `cleanup-stale-branches` input (default `false`, non-breaking). When enabled, it deletes branches with no commits for `days-before-branch-stale` days (default 14), skipping the default branch, protected branches, and any branch with an open PR.

## Why

The existing `actions/stale` step only deletes a branch when it closes a PR attached to it. Repos that accumulate branches pushed with no PR at all (e.g. `cc-scripts-repository`, which has 78 branches and only 3 open PRs) never get those cleaned up. Rather than every repo hand-rolling this, it's now one opt-in flag on the shared template.

## How to review

- `cleanup-stale-branches` defaults to `false`, so no behavior changes for existing consumers.
- Check the new `delete-stale-branches` job: skips default branch, protected branches, and branches with an open PR before deleting.
- README example updated with the two new inputs, following the doc convention in AGENTS.md.