### PR TITLE
chore(deps): bump Staffbase/github-action-jira-release-tagging from 1.7.1 to 1.7.3

### DIFF
--- a/.github/workflows/template_jira_tagging.yml
+++ b/.github/workflows/template_jira_tagging.yml
@@ -39,7 +39,7 @@ jobs:
           TAG_MATCHER: ${{ inputs.tag-matcher }}
 
       - name: Add release notes to JIRA tickets
-        uses: Staffbase/github-action-jira-release-tagging@09f652cf865041deb8890928e330eb2aa14f6885 # v1.7.1
+        uses: Staffbase/github-action-jira-release-tagging@6415d3f0dbaba53113f1269884d72bc36ab179d9 # v1.7.3
         env:
           JIRA_BASEURL: ${{ secrets.jira-url }}
           JIRA_TOKEN: ${{ secrets.jira-token }}


### PR DESCRIPTION
## Why

Every repo running `template_jira_tagging.yml` logs this on every run:

```
Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on
Node.js 24: Staffbase/github-action-jira-release-tagging@09f652cf...
```

`github-action-jira-release-tagging` declared `using: 'node20'`. That was fixed in Staffbase/github-action-jira-release-tagging#209 and released as **v1.7.3**, which ships `using: 'node24'`. This template still pins v1.7.1, so consumers keep emitting the warning.

## Change

```diff
-        uses: Staffbase/github-action-jira-release-tagging@09f652cf865041deb8890928e330eb2aa14f6885 # v1.7.1
+        uses: Staffbase/github-action-jira-release-tagging@6415d3f0dbaba53113f1269884d72bc36ab179d9 # v1.7.3
```

`6415d3f0` is the commit `v1.7.3` points at; verified that `action.yml` at that tag reads `using: 'node24'`.

## Why this needs a manual PR

This repo's `dependabot.yml` ignores `version-update:semver-patch` for all github-actions, and 1.7.1 → 1.7.3 is a patch bump — Dependabot will never propose it.

## Risk

Low. The runner already **forces** the action onto Node 24 today ("being forced to run on Node.js 24"), so it has been executing on Node 24 in production for some time, including in successful runs. v1.7.3 makes the declaration match reality. Between v1.7.1 and v1.7.3 the only other changes are dependency bumps and CVE patches (undici, eslint, ncc, js-yaml, minimatch, brace-expansion, picomatch) — no behaviour changes to the action itself.

## Note

This does not address the `504 Gateway Time-out` from `callWebhook` currently failing "Annotate Jira Issues" in plugin-forms — that's a Jira-side timeout, unrelated to the Node version (the last *successful* run carried the identical Node 20 warning).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
