### PR TITLE
feat(CORE-4981): add multi-arch toggle to gitops template

### DIFF
--- a/.github/workflows/template_gitops.yml
+++ b/.github/workflows/template_gitops.yml
@@ -90,6 +90,16 @@ on:
         type: boolean
         default: false
         description: "Create GitHub Deployments on the source repository and write tracking annotations to the GitOps CRs"
+      multi-arch:
+        required: false
+        type: boolean
+        default: false
+        description: "Build linux/amd64 and linux/arm64 natively via a job matrix and merge them into one multi-arch image. Disabled by default (single-arch build using docker-build-platform). See gitops-github-action README 'Multi-Arch Images'."
+      multiarch-artifact-name:
+        required: false
+        type: string
+        default: "docker-digests"
+        description: "Base name of the artifact carrying the per-architecture digests between the build and merge jobs. Only needs changing when a workflow builds more than one multi-arch image, otherwise the digests get mixed up."
     # waiting for: https://github.com/github-community/community/discussions/17554
     secrets:
       docker-username:
@@ -115,7 +125,7 @@ jobs:
   gitops:
     name: GitOps
     runs-on: ${{ inputs.runs-on }}
-    if: github.ref == 'refs/heads/dev' || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/')
+    if: inputs.multi-arch != true && (github.ref == 'refs/heads/dev' || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/'))
     permissions:
       contents: read
       deployments: write
@@ -151,6 +161,109 @@ jobs:
           docker-build-target: ${{ inputs.docker-build-target }}
           docker-build-outputs: ${{ inputs.docker-build-outputs }}
           docker-build-platforms: ${{ inputs.docker-build-platform }}
+          docker-build-provenance: ${{ inputs.docker-build-provenance }}
+          docker-disable-retagging: ${{ inputs.docker-disable-retagging }}
+          docker-file: ${{ inputs.docker-file }}
+          docker-image: ${{ inputs.docker-image }}
+          docker-custom-tag: ${{ inputs.docker-custom-tag }}
+          docker-tag-timestamp: ${{ inputs.docker-tag-timestamp }}
+          gitops-organization: ${{ inputs.gitops-organization }}
+          gitops-repository: ${{ inputs.gitops-repository }}
+          gitops-user: ${{ inputs.gitops-user }}
+          gitops-email: ${{ inputs.gitops-email }}
+          gitops-token: ${{ env.USING_APP_CREDENTIALS == 'true' && steps.get_token.outputs.token || secrets.gitops-token }}
+          gitops-dev: ${{ inputs.gitops-dev }}
+          gitops-stage: ${{ inputs.gitops-stage }}
+          gitops-prod: ${{ inputs.gitops-prod }}
+          upwind-client-id: ${{ inputs.upwind-client-id }}
+          upwind-client-secret: ${{ secrets.upwind-client-secret }}
+          upwind-organization-id: ${{ inputs.upwind-organization-id }}
+          working-directory: ${{ inputs.working-directory }}
+
+  gitops-build:
+    name: Build (${{ matrix.arch }})
+    runs-on: ${{ matrix.runs-on }}
+    if: inputs.multi-arch == true && (github.ref == 'refs/heads/dev' || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/'))
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: amd64
+            runs-on: ubuntu-24.04
+          - arch: arm64
+            runs-on: ubuntu-24.04-arm
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: GitOps (build and push by digest)
+        # pending https://github.com/Staffbase/gitops-github-action/pull/159, pin to a release once merged
+        uses: Staffbase/gitops-github-action@8c26511aec8f9ca0d2f4337aa8164d918e3a5445 # CORE-4981-multi-arch-builds
+        with:
+          multiarch-mode: build
+          multiarch-artifact-name: ${{ inputs.multiarch-artifact-name }}
+          docker-registry: ${{ inputs.docker-registry }}
+          docker-username: ${{ secrets.docker-username }}
+          docker-password: ${{ secrets.docker-password }}
+          docker-build-args: |
+            ${{ inputs.docker-build-args }}
+            GONOSUMDB=${{ vars.gonosumdb }}
+          docker-build-secrets: ${{ secrets.docker-build-secrets }}
+          docker-build-secret-files: ${{ secrets.docker-build-secret-files }}
+          docker-build-target: ${{ inputs.docker-build-target }}
+          docker-build-provenance: ${{ inputs.docker-build-provenance }}
+          docker-disable-retagging: ${{ inputs.docker-disable-retagging }}
+          docker-file: ${{ inputs.docker-file }}
+          docker-image: ${{ inputs.docker-image }}
+          docker-custom-tag: ${{ inputs.docker-custom-tag }}
+          docker-tag-timestamp: ${{ inputs.docker-tag-timestamp }}
+          working-directory: ${{ inputs.working-directory }}
+
+  gitops-merge:
+    name: Merge and Deploy
+    needs: gitops-build
+    runs-on: ${{ inputs.runs-on }}
+    if: inputs.multi-arch == true && (github.ref == 'refs/heads/dev' || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/'))
+    permissions:
+      contents: read
+      deployments: write
+
+    env:
+      USING_APP_CREDENTIALS: ${{ secrets.client-id != '' && secrets.private-key != '' }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Get App Token
+        if: ${{ env.USING_APP_CREDENTIALS == 'true' }}
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        id: get_token
+        with:
+          client-id: ${{ secrets.client-id }}
+          private-key: ${{ secrets.private-key }}
+          owner: ${{inputs.gitops-organization }}
+
+      - name: GitOps (merge manifests and deploy)
+        id: gitops
+        # pending https://github.com/Staffbase/gitops-github-action/pull/159, pin to a release once merged
+        uses: Staffbase/gitops-github-action@8c26511aec8f9ca0d2f4337aa8164d918e3a5445 # CORE-4981-multi-arch-builds
+        with:
+          multiarch-mode: merge
+          multiarch-artifact-name: ${{ inputs.multiarch-artifact-name }}
+          docker-registry: ${{ inputs.docker-registry }}
+          docker-username: ${{ secrets.docker-username }}
+          docker-password: ${{ secrets.docker-password }}
+          docker-build-args: |
+            ${{ inputs.docker-build-args }}
+            GONOSUMDB=${{ vars.gonosumdb }}
+          docker-build-secrets: ${{ secrets.docker-build-secrets }}
+          docker-build-secret-files: ${{ secrets.docker-build-secret-files }}
+          docker-build-target: ${{ inputs.docker-build-target }}
+          docker-build-outputs: ${{ inputs.docker-build-outputs }}
           docker-build-provenance: ${{ inputs.docker-build-provenance }}
           docker-disable-retagging: ${{ inputs.docker-disable-retagging }}
           docker-file: ${{ inputs.docker-file }}

--- a/.github/workflows/template_gitops.yml
+++ b/.github/workflows/template_gitops.yml
@@ -200,8 +200,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: GitOps (build and push by digest)
-        # pending https://github.com/Staffbase/gitops-github-action/pull/159, pin to a release once merged
-        uses: Staffbase/gitops-github-action@8c26511aec8f9ca0d2f4337aa8164d918e3a5445 # CORE-4981-multi-arch-builds
+        uses: Staffbase/gitops-github-action@158275454d56fd8fa923995220ee1b9eb1030032 # v8.2.1
         with:
           multiarch-mode: build
           multiarch-artifact-name: ${{ inputs.multiarch-artifact-name }}
@@ -249,8 +248,7 @@ jobs:
 
       - name: GitOps (merge manifests and deploy)
         id: gitops
-        # pending https://github.com/Staffbase/gitops-github-action/pull/159, pin to a release once merged
-        uses: Staffbase/gitops-github-action@8c26511aec8f9ca0d2f4337aa8164d918e3a5445 # CORE-4981-multi-arch-builds
+        uses: Staffbase/gitops-github-action@158275454d56fd8fa923995220ee1b9eb1030032 # v8.2.1
         with:
           multiarch-mode: merge
           multiarch-artifact-name: ${{ inputs.multiarch-artifact-name }}

--- a/README.md
+++ b/README.md
@@ -288,6 +288,10 @@ jobs:
         your files
       # optional: defines the github runner for the gitops step if (e.g. ubuntu-24.04-arm for arm builds), default: ubuntu-24.04
       runs-on: ubuntu-24.04-arm
+      # optional: build linux/amd64 and linux/arm64 natively via a job matrix and merge them into one multi-arch image, default: false
+      multi-arch: true
+      # optional: base name of the artifact carrying the per-arch digests, only change it when building more than one multi-arch image in a workflow, default: docker-digests
+      multiarch-artifact-name: docker-digests-my-service
       # optional: Upwind.io client ID
       upwind-client-id: ${{ vars.UPWIND_CLIENT_ID }}
       # optional: Upwind.io organization ID


### PR DESCRIPTION
## What changed

New `multi-arch` input (boolean, default `false`) on `template_gitops.yml`. When enabled, the template fans out into a build matrix (`amd64` on `ubuntu-24.04`, `arm64` on `ubuntu-24.04-arm`) using `multiarch-mode: build`, then a merge job combines the digests via `multiarch-mode: merge` and runs the GitOps/Upwind steps as usual.

Callers that do not set it keep the existing single `gitops` job, unchanged and still pinned to v8.0.1 — same job id, same display name, so required status checks are unaffected.

`multiarch-artifact-name` is exposed too, so workflows building more than one image can keep their digests apart.

## Why it changed

Recovery/failover regions have no ARM capacity, so images deployed there must ship both `linux/amd64` and `linux/arm64`. Wiring the matrix into the shared template means consumers flip one boolean instead of restructuring their workflow.

## How to test it

Used here: https://github.com/Staffbase/slo-operator/pull/37

<img width="895" height="555" alt="Screenshot 2026-09-02 at 16 32 39" src="https://github.com/user-attachments/assets/469d5602-88a3-4612-8c4a-483545fab460" />


`yamllint .github/workflows/` passes. End to end: point a test repo at this branch with `multi-arch: true` and verify `docker buildx imagetools inspect <tag>` lists both platforms — being validated now via Staffbase/slo-operator.



---
<sub>The changes and/or the PR description has generated by with the help of OpenCode.</sub>