### PR TITLE
feat!: upgrade changesets/action to v2.1.2

### DIFF
--- a/.github/workflows/template_changeset_release.yml
+++ b/.github/workflows/template_changeset_release.yml
@@ -66,13 +66,14 @@ jobs:
 
       - name: Create Release Pull Request
         id: changesets
-        uses: changesets/action@e4156907cdd269dcaa37f03263be504a3570994d # v1.6.0
+        uses: changesets/action@ae32849d5ba541f9ae29e40e22a623bc13562f51 # v2.1.2
         with:
-          commit: 'chore(release): Bump package version'
-          title: '📦 Release New Version'
-          createGithubReleases: true
-          version: ${{ inputs.version-script }}
-          publish: ${{ inputs.publish-script }}
+          github-token: ${{ steps.get_token.outputs.token }}
+          commit-message: 'chore(release): Bump package version'
+          pr-title: '📦 Release New Version'
+          create-github-releases: true
+          version-script: ${{ inputs.version-script }}
+          publish-script: ${{ inputs.publish-script }}
         env:
           GITHUB_TOKEN: ${{ steps.get_token.outputs.token }}
           HOME: ${{ github.workspace }}

--- a/.github/workflows/template_changeset_release.yml
+++ b/.github/workflows/template_changeset_release.yml
@@ -72,6 +72,7 @@ jobs:
           commit-message: 'chore(release): Bump package version'
           pr-title: '📦 Release New Version'
           create-github-releases: true
+          push-with-git-cli: true
           version-script: ${{ inputs.version-script }}
           publish-script: ${{ inputs.publish-script }}
         env:


### PR DESCRIPTION
### Type of Change

- [x] Bugfix
- [ ] Enhancement / new feature
- [ ] Refactoring
- [ ] Documentation

### Description

This upgrades `template_changeset_release.yml` to use `changesets/action` v2.1.2.
**Breaking change:** `changesets/action` v2 explicitly refuses to run against `@changesets/cli` v2, so `@changesets/cli` must be updated to v3 for the new template version to work.

Why this change was done:
Until now `changesets/action` v1.x was used, which detects a release by scanning the publish script's stdout for a `New tag:` line. `@changesets/cli` v3 stopped printing that line (it prints a `Successfully published:` list instead), so consumers who upgrade to CLI v3 get successful npm publishes but no git tag or GitHub Release.

Renamed the inputs because of the breaking changes, set ` push-with-git-cli: true` because v1's commitMode defaulted to "git-cli". This keeps the existing push/commit behavior unchanged so the PR stays scoped to the CLI v3 compatibility fix.

### How to review

Check the diff against the changesets/action v2 README (https://github.com/changesets/action/blob/v2.1.2/README.md). Ideally validate with a real release run on `frontend-api-client` or `oxc-shared` (both CLI v3) before merging.

### Checklist

- [x] Add relevant labels (for example type of change or patch/minor/major)
- [ ] Make sure not to introduce some mistakes
- [ ] Update documentation
- [ ] Review the Contributing Guideline and sign CLA
- [ ] Reference relevant issue(s) and close them after merging