### PR TITLE
fix(autodev): don't cancel in-progress autodev runs, only serialize them

### DIFF
--- a/.github/workflows/template_autodev.yml
+++ b/.github/workflows/template_autodev.yml
@@ -64,11 +64,15 @@ jobs:
 
     # This job rebuilds `branch` from scratch (base + all labeled PRs) and force-pushes it, so
     # overlapping runs race on which force-push lands last, not which reflects the newest `base`.
-    # Serialize per base/branch and drop stale in-flight runs so a late-finishing run built from
-    # an older `base` snapshot can't overwrite a newer one.
+    # Serialize per base/branch so runs never overlap. Do NOT cancel-in-progress: callers whose
+    # `base` gets frequent automated commits (e.g. Flux image automation pushing to `main` every
+    # few seconds) would otherwise cancel every run before it finishes, so `branch` never gets
+    # rebuilt at all. Queuing (instead of cancelling) still fixes the original race, since a
+    # queued run re-checks out `base` fresh once it actually starts; GitHub also collapses a
+    # backlog of queued runs down to just the latest one, so the queue can't grow unbounded.
     concurrency:
       group: autodev-${{ inputs.base }}-${{ inputs.branch }}
-      cancel-in-progress: true
+      cancel-in-progress: false
 
     env:
       USING_APP_CREDENTIALS: ${{ secrets.client_id != '' && secrets.private_key != '' }}


### PR DESCRIPTION
## Background

[PR #490](https://github.com/Staffbase/gha-workflows/pull/490) added a `concurrency` group with `cancel-in-progress: true` to the `autodev` job to stop overlapping runs from racing to force-push the target branch (the "rollback-then-recovery" blip described there).

That fix caused a regression in callers whose `base` branch receives very frequent automated commits — most notably `Staffbase/mops`, where `staffbase-flux-toolkit[bot]` pushes image-tag bumps to `main` every 10-30 seconds during busy periods. Since the concurrency group is `autodev-${{ inputs.base }}-${{ inputs.branch }}` and `mops` uses the default `base=main`/`branch=dev`, every one of those bot pushes shares the same group and cancels whatever `autodev` run was already in flight, before it could finish. In practice `dev` stopped being rebuilt at all — see [Staffbase/mops#18618](https://github.com/Staffbase/mops/pull/18618), where `mops` had to roll back to a pre-#490 version of this workflow as a stopgap.

I confirmed this against the live run history for `mops`'s Autodev workflow: during an active period, nearly every run was `cancelled`, with only rare completions squeezed in between bot pushes.

## Fix

Change `cancel-in-progress` from `true` to `false`.

- Runs still can't overlap — the concurrency group still serializes them, which is what actually fixes the original force-push race from #490.
- Nothing gets killed mid-run: a queued run performs its own fresh checkout of `base` once it actually starts, so it can't force-push stale content even though it queued behind an earlier trigger.
- GitHub collapses a backlog of queued runs in the same group down to just the latest one, so the queue can't grow unbounded even under sustained high-frequency bot traffic.

## How to review

- Read the updated comment above the `concurrency` block in [template_autodev.yml](.github/workflows/template_autodev.yml) for the reasoning.
- Confirm this still closes the race #490 was written for (two triggers firing near-simultaneously should serialize, not overlap).
- Confirm this resolves the "never succeeds" symptom for high-frequency callers like `mops` once they re-bump to a release containing this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)